### PR TITLE
APPSRE-10846 validate rds.logical_replication

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+# this file is used by asdf to automatically select the correct tool versions
+# but it also serves as a reference for non-asdf users
+python 3.11.4

--- a/er_aws_rds/errors.py
+++ b/er_aws_rds/errors.py
@@ -1,0 +1,2 @@
+class RDSLogicalReplicationError(Exception):
+    """Custom exception for RDS logical replication setting errors"""

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -1,0 +1,25 @@
+import pytest
+from cdktf import Testing
+
+from er_aws_rds.errors import RDSLogicalReplicationError
+from er_aws_rds.input import AppInterfaceInput, Parameter
+
+from .conftest import input_data
+
+Testing.__test__ = False
+
+
+def test_validate_parameter_rds_replication() -> None:
+    """Test that rds.logical_replication parameter must be set to 'pending-reboot'"""
+    with pytest.raises(RDSLogicalReplicationError):
+        AppInterfaceInput.model_validate(
+            input_data(
+                parameters=[
+                    Parameter(
+                        name="rds.logical_replication",
+                        value="1",
+                        apply_method="immediate",
+                    ),
+                ]
+            )
+        )

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -35,7 +35,7 @@ class TestMain:
             },
         )
 
-    def test_shuold_contain_parameter_group(self) -> None:
+    def test_should_contain_parameter_group(self) -> None:
         """Test should_contain_parameter_group"""
         assert Testing.to_have_resource_with_properties(
             self.synthesized,


### PR DESCRIPTION
Content:
- validating rds.logical_replication is applied via `pending-reboot` (see https://github.com/app-sre/qontract-reconcile/pull/4653)
- .tool-versions
- fixing some typos
