### PR TITLE
fix(password): generate password with allowed special chars

### DIFF
--- a/er_aws_rds/rds.py
+++ b/er_aws_rds/rds.py
@@ -110,7 +110,7 @@ class Stack(TerraformStack):
             self,
             id=f"{self.data.identifier}-password",
             length=20,
-            min_special=0,  # need to be 0 to import current password. It should be improved in next version of module once the instaces are imported.
+            special=False,  # MasterUserPassword: some special chars are not allowed
             min_numeric=0,
             keepers={"reset_password": self.data.reset_password or ""},
         ).result

--- a/er_aws_rds/rds.py
+++ b/er_aws_rds/rds.py
@@ -110,7 +110,9 @@ class Stack(TerraformStack):
             self,
             id=f"{self.data.identifier}-password",
             length=20,
-            special=False,  # MasterUserPassword: some special chars are not allowed
+            # MasterUserPassword Constraints in https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html
+            override_special="!#$%*()-_=+[]{}<>:?",
+            min_special=0,  # need to be 0 to import current password. It should be improved in next version of module once the instaces are imported.
             min_numeric=0,
             keepers={"reset_password": self.data.reset_password or ""},
         ).result


### PR DESCRIPTION
no special chars in password to fix error

```
CDKTF  Error: creating RDS DB Instance (xxx): InvalidParameterValue: The parameter MasterUserPassword is not a valid password. Only printable ASCII characters besides '/', '@', '"', ' ' may be used.
```

aws [doc](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html)

> Can include any printable ASCII character except "/", """, or "@". For RDS for Oracle, can't include the "&" (ampersand) or the "'" (single quotes) character.
