### PR TITLE
fix(password): generate password without special chars

### DIFF
--- a/er_aws_rds/rds.py
+++ b/er_aws_rds/rds.py
@@ -110,9 +110,9 @@ class Stack(TerraformStack):
             self,
             id=f"{self.data.identifier}-password",
             length=20,
-            # MasterUserPassword Constraints in https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html
-            override_special="!#$%*()-_=+[]{}<>:?",
-            min_special=0,  # need to be 0 to import current password. It should be improved in next version of module once the instaces are imported.
+            # avoid special chars for MasterUserPassword Constraints in https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html
+            # also consistent with terraform-resources random password generation
+            special=False,
             min_numeric=0,
             keepers={"reset_password": self.data.reset_password or ""},
         ).result


### PR DESCRIPTION
Rework random password config using https://github.com/app-sre/er-aws-rds/pull/5/commits/6093d5ca15a939271ad65bca20f5091560773fdc.

Some special chars are causing issues in application config, disable special chars to keep consistent with https://github.com/app-sre/qontract-reconcile/blob/c175f4df07fb7e42edaa58c886530186acfd9f6e/reconcile/utils/terrascript_aws_client.py#L2091-L2094