### PR TITLE
fix: add user and password to output when restore from snapshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,5 +37,6 @@ dev:
 	# Prepare local development environment
 	uv sync
 	# The CDKTF python module generation needs at least 12GB of memory!
+	mkdir -p .gen
 	$(CONTAINER_ENGINE) run --rm -it -v $(PWD)/:/home/app/src -v $(PWD)/.gen:/cdktf-providers:z --entrypoint cdktf-provider-sync quay.io/redhat-services-prod/app-sre-tenant/er-base-cdktf-main/er-base-cdktf-main:latest /cdktf-providers
 	cp sitecustomize.py $(SITE_PACKAGES_DIR)

--- a/er_aws_rds/rds.py
+++ b/er_aws_rds/rds.py
@@ -223,11 +223,7 @@ class Stack(TerraformStack):
                 value=self.data.ca_cert.to_vault_ref(),
             )
 
-        if not (
-            self.data.replica_source
-            or self.data.replicate_source_db
-            or self.data.snapshot_identifier
-        ):
+        if not (self.data.replica_source or self.data.replicate_source_db):
             TerraformOutput(
                 self,
                 f"{self.data.identifier}__db_user",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,10 @@ from er_aws_rds.input import AppInterfaceInput, Parameter
 Testing.__test__ = False
 
 
-def input_data(parameters: Iterable[Parameter] | None) -> dict:
+def input_data(
+    parameters: Iterable[Parameter] | None,
+    snapshot_identifier: str | None = None,
+) -> dict:
     """Returns a parsed JSON input as dict"""
     if not parameters:
         parameters = [
@@ -45,7 +48,10 @@ def input_data(parameters: Iterable[Parameter] | None) -> dict:
             "publicly_accessible": true,
             "apply_immediately": true,
             "identifier": "test-rds",
-            "enhanced_monitoring": true,
+            "enhanced_monitoring": true,"""
+        f"""
+            "snapshot_identifier": {json.dumps(snapshot_identifier)},"""
+        """
             "parameter_group": {
                 "name": "postgres-14",
                 "family": "postgres14",
@@ -98,6 +104,11 @@ def input_data(parameters: Iterable[Parameter] | None) -> dict:
     )
 
 
-def input_object() -> AppInterfaceInput:
+def input_object(snapshot_identifier: str | None = None) -> AppInterfaceInput:
     """Returns an AppInterfaceInput object"""
-    return AppInterfaceInput.model_validate(input_data(parameters=None))
+    return AppInterfaceInput.model_validate(
+        input_data(
+            parameters=None,
+            snapshot_identifier=snapshot_identifier,
+        )
+    )

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from cdktf import Testing
 from cdktf_cdktf_provider_aws.db_instance import DbInstance
@@ -5,21 +7,26 @@ from cdktf_cdktf_provider_aws.db_parameter_group import DbParameterGroup
 from cdktf_cdktf_provider_aws.iam_role import IamRole
 from cdktf_cdktf_provider_aws.iam_role_policy_attachment import IamRolePolicyAttachment
 
+from er_aws_rds.input import VaultSecret
 from er_aws_rds.rds import Stack
 
 from .conftest import input_object
 
 
-@pytest.fixture
-def stack() -> Stack:
-    """Stack fixture"""
-    return Stack(Testing.app(), "CDKTF", input_object())
-
-
-@pytest.fixture
-def synth(stack: Stack) -> str:
-    """Synth fixture"""
+def build_synth(snapshot_identifier: str | None = None) -> str:
+    """Create Synth"""
+    stack = Stack(
+        Testing.app(),
+        "CDKTF",
+        input_object(snapshot_identifier=snapshot_identifier),
+    )
     return Testing.synth(stack)
+
+
+@pytest.fixture
+def synth() -> str:
+    """Synth fixture"""
+    return build_synth()
 
 
 def test_should_contain_rds_instance(synth: str) -> None:
@@ -76,3 +83,40 @@ def test_enhanced_monitoring(synth: str) -> None:
             "policy_arn": "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole",
         },
     )
+
+
+@pytest.mark.parametrize("snapshot_identifier", [None, "some-identifier"])
+def test_outputs(snapshot_identifier: str | None) -> None:
+    """Test outputs"""
+    synth = build_synth(snapshot_identifier)
+    result = json.loads(synth)
+    ca_cert = VaultSecret(
+        path="app-interface/global/rds-ca-cert",
+        field="us-east-1",
+        version=2,
+        q_format=None,
+    )
+    expected_outputs = {
+        "test-rds__db_ca_cert": {
+            "sensitive": False,
+            "value": f"__vault__:{ca_cert.model_dump_json()}",
+        },
+        "test-rds__db_host": {
+            "value": "${aws_db_instance.test-rds.address}",
+        },
+        "test-rds__db_name": {
+            "value": "${aws_db_instance.test-rds.db_name}",
+        },
+        "test-rds__db_port": {
+            "value": "${aws_db_instance.test-rds.port}",
+        },
+        "test-rds__db_user": {
+            "sensitive": True,
+            "value": "${aws_db_instance.test-rds.username}",
+        },
+        "test-rds__db_password": {
+            "sensitive": True,
+            "value": "${aws_db_instance.test-rds.password}",
+        },
+    }
+    assert result["output"] == expected_outputs


### PR DESCRIPTION
[APPSRE-11439](https://issues.redhat.com/browse/APPSRE-11439)

Ensure same output regardless of restore from snapshot or not.

This pull request includes several changes to the `Makefile`, `er_aws_rds/rds.py`, `tests/conftest.py`, and `tests/test_module.py` files to improve functionality and add new features. The most important changes include creating a directory for generated files, modifying the `_outputs` method, updating the `input_data` and `input_object` functions, and adding a new test for outputs.

Improvements to the development environment:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R40): Added a command to create the `.gen` directory to ensure the necessary directory exists before running the `cdktf-provider-sync` command.

Enhancements to the RDS module:

* [`er_aws_rds/rds.py`](diffhunk://#diff-5f4b3556fb464258f0babf11c91bbada5fcc8ecb4422e73a3f4eb14a02701852L226-R226): Modified the `_outputs` method to remove the check for `snapshot_identifier` when determining whether to create a `TerraformOutput` for the `db_user`.

Updates to test configurations and functions:

* [`tests/conftest.py`](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L11-R14): Updated the `input_data` function to accept an optional `snapshot_identifier` parameter and include it in the returned JSON data. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L11-R14) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L48-R54)
* [`tests/conftest.py`](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L101-R114): Updated the `input_object` function to accept an optional `snapshot_identifier` parameter and pass it to the `input_data` function.

New test cases:

* [`tests/test_module.py`](diffhunk://#diff-db77e9606f783b8ebba6b490fb9a3109b5978248602226560f5eca46094d6232R86-R122): Added a new test case `test_outputs` to verify the outputs of the RDS module, including handling of the `snapshot_identifier` parameter.