### PR TITLE
fix: populate parameter group name for rds instance

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,5 @@ module/.terraform*
 module/*.tftest.hcl
 module/backend.tf
 module/tfvars.json
+module/plan
+module/plan.json

--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,5 @@ module/.terraform/
 module/.terraform.*
 module/backend.tf
 module/tfvars.json
+module/plan
+module/plan.json

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ CONTAINER_ENGINE ?= $(shell which podman >/dev/null 2>&1 && echo podman || echo 
 format:
 	uv run ruff check
 	uv run ruff format
-	terraform fmt -check module/
 	terraform fmt module/
 
 .PHONY: image_tests

--- a/cdktf.json
+++ b/cdktf.json
@@ -1,7 +1,0 @@
-{
-  "language": "python",
-  "app": "er-aws-rds",
-  "sendCrashReports": "false",
-  "terraformProviders": [],
-  "projectId": "49778ce7-523f-482c-a0e7-bad21132b58c"
-}

--- a/er_aws_rds/config.py
+++ b/er_aws_rds/config.py
@@ -22,3 +22,7 @@ def generate_tf_files() -> None:
     create_backend_tf_file(ai_input.provision)
     tf = TerraformModuleData(ai_input=ai_input)
     create_tf_vars_json(tf)
+
+
+if __name__ == "__main__":
+    generate_tf_files()

--- a/er_aws_rds/input.py
+++ b/er_aws_rds/input.py
@@ -249,12 +249,15 @@ class Rds(RdsAppInterface):
 
     @model_validator(mode="after")
     def parameter_groups(self) -> "Rds":
-        "Sets the right parameter group names. The instance identifier is used as prefix on each pg"
-        "This way each instance will have its own parameter group, withouth re-using them on multiple instances"
+        """
+        Sets the right parameter group names. The instance identifier is used as prefix on each pg.
+
+        This way each instance will have its own parameter group, without re-using them on multiple instances.
+        """
         if self.parameter_group:
-            self.parameter_group.computed_pg_name = (
-                f"{self.identifier}-{self.parameter_group.name or 'pg'}"
-            )
+            name = f"{self.identifier}-{self.parameter_group.name or 'pg'}"
+            self.parameter_group.computed_pg_name = name
+            self.parameter_group_name = name
 
         if self.old_parameter_group and not self.parameter_group:
             msg = "old_parameter_group must be used with parameter_group. old_parameter_group is only used for RDS major version upgrades"

--- a/er_aws_rds/input.py
+++ b/er_aws_rds/input.py
@@ -213,11 +213,11 @@ class Rds(RdsAppInterface):
         if self.replicate_source_db:
             msg = "Only one of replicate_source_db or replica_source can be defined"
             raise ValueError(msg)
-        if self.replica_source.region != self.region or self.db_subnet_group_name:
+        if self.replica_source.region != self.region:
             # Cross-region replication or different db_subnet_group_name.
             # The ARN must be set in the replicate_source_db attribute for these cases.
             # The ARN is resolved in the module using a Datasource.
-            # The Datasource required attribuets are fed with the replica_source variable.
+            # The Datasource required attributes are fed with the replica_source variable.
             if not self.db_subnet_group_name:
                 msg = "db_subnet_group_name must be defined for cross-region replicas"
                 raise ValueError(msg)

--- a/hooks/post_plan.py
+++ b/hooks/post_plan.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
-
 import logging
-import logging.config
 import sys
 
 import semver
@@ -106,7 +104,7 @@ if __name__ == "__main__":
     logger = logging.getLogger(__name__)
 
     RuntimeEnvVars.check([RuntimeEnvVars.PLAN_FILE_JSON])
-    terraform_plan_json = RuntimeEnvVars.PLAN_FILE_JSON.get()
+    terraform_plan_json = RuntimeEnvVars.PLAN_FILE_JSON.get() or ""
 
     app_interface_input: AppInterfaceInput = parse_model(
         AppInterfaceInput,

--- a/hooks/pre_plan.py
+++ b/hooks/pre_plan.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
 
     RuntimeEnvVars.check([RuntimeEnvVars.TERRAFORM_CMD, RuntimeEnvVars.TF_VARS_FILE])
 
-    terraform_cmd = RuntimeEnvVars.TERRAFORM_CMD.get().split()
+    terraform_cmd = (RuntimeEnvVars.TERRAFORM_CMD.get() or "").split()
     terraform_vars_file = RuntimeEnvVars.TF_VARS_FILE.get()
 
     logger.info("Running Migration Process CDKTF -> Terraform")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,15 +36,10 @@ generate-tf-config = 'er_aws_rds.config:generate_tf_files'
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.hatch.build.targets.sdist]
-only-include = ["er_aws_msk"]
-
 # Ruff configuration
 [tool.ruff]
 line-length = 88
 target-version = 'py311'
-src = ["er_aws_msk"]
-extend-exclude = [".gen"]
 fix = true
 
 [tool.ruff.lint]
@@ -93,7 +88,7 @@ known-first-party = ["er_aws_rds"]
 
 # Mypy configuration
 [tool.mypy]
-files = ["er_aws_rds", "tests"]
+files = ["er_aws_rds", "hooks", "tests"]
 enable_error_code = ["truthy-bool", "redundant-expr"]
 no_implicit_optional = true
 check_untyped_defs = true

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -43,10 +43,11 @@ def test_parameter_group_name() -> None:
     """Test correct parameter group names are set"""
     model = AppInterfaceInput.model_validate(input_data())
     assert model.data.parameter_group is not None
-    assert (
-        model.data.parameter_group.computed_pg_name
-        == f"{model.data.identifier}-{model.data.parameter_group.name}"
+    expected_parameter_group_name = (
+        f"{model.data.identifier}-{model.data.parameter_group.name}"
     )
+    assert model.data.parameter_group.computed_pg_name == expected_parameter_group_name
+    assert model.data.parameter_group_name == expected_parameter_group_name
 
 
 def test_parameter_group_name_without_pg_name() -> None:

--- a/tests/test_plan_validation.py
+++ b/tests/test_plan_validation.py
@@ -1,4 +1,5 @@
 from external_resources_io.terraform import Action, Plan
+
 from hooks.post_plan import RDSPlanValidator
 
 from .conftest import input_object


### PR DESCRIPTION
Bugfix and cleanup as https://github.com/app-sre/er-aws-rds/pull/80

Main bug is missing `parameter_group_name` in rds instance, so all new instances are using default parameter group.

Other small refactors:

### Improvements to `.dockerignore`:

* [`.dockerignore`](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R7-R8): Added `module/plan` and `module/plan.json` to ignore list.

### Modifications to `Makefile`:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L7): Removed the `terraform fmt -check module/` command from the `format` target.

### Changes to `config.py`:

* [`er_aws_rds/config.py`](diffhunk://#diff-b49e08040940d41a552887fa6aad7408433b66cc813f76976204e187ef3b5a88R25-R28): Added a main entry point to call `generate_tf_files()` when the script is run directly.

### Code cleanup and validation improvements:

* [`hooks/post_plan.py`](diffhunk://#diff-e1e101fc08c044624f7b3896a524c3e118c82887f9fa2f4e88b6b3c2c58959d6L109-R107): Ensured `terraform_plan_json` is never `None` by providing a default empty string.
* [`hooks/pre_plan.py`](diffhunk://#diff-e9cfa55a17c10cd94fb684a90a0e02c4b4fef1ce01cbf10ef67656f91872ca56L76-R76): Ensured `terraform_cmd` is never `None` by providing a default empty string.

These changes aim to streamline the development process, improve code readability, and ensure better handling of edge cases.