### PR TITLE
Fix plan validation for read replicas

### DIFF
--- a/er_aws_rds/input.py
+++ b/er_aws_rds/input.py
@@ -133,7 +133,7 @@ class Rds(RdsAppInterface):
 
     model_config = ConfigDict(extra="allow")
     identifier: str
-    engine: str | None = None
+    engine: str = "postgres"
     allow_major_version_upgrade: bool | None = False
     availability_zone: str | None = None
     monitoring_interval: int | None = None
@@ -191,12 +191,15 @@ class Rds(RdsAppInterface):
 
     @model_validator(mode="after")
     def unset_replica_or_snapshot_not_allowed_attrs(self) -> "Rds":
-        """Some attributes are not allowed if the instance is a replica or needs to be created from a snapshot"""
+        """
+        Some attributes are not allowed if the instance is a read replica or is created from a snapshot.
+
+        engine is not removed because it's needed in the plan validation.
+        """
         if self.replica_source or self.replicate_source_db or self.snapshot_identifier:
             self.username = None
             self.password = None
             self.name = None
-            self.engine = None
             self.allocated_storage = None
         return self
 

--- a/hooks/post_plan.py
+++ b/hooks/post_plan.py
@@ -89,7 +89,7 @@ class RDSPlanValidator:
         for u in self.aws_db_instance_creations:
             if not u.change or not u.change.after:
                 continue
-            engine = u.change.after["engine"]
+            engine = self.input.data.engine
             version = u.change.after["engine_version"]
             if not self.aws_api.is_rds_engine_version_available(
                 engine=engine, version=version


### PR DESCRIPTION
* `engine` must not be set when creating a read replica as is derived from the main instance. 
* The plan output when creating a read replica does not include the `engine` attribute. 
* We need to know the `engine` to validate the plan. 

Instead of relying on the plan to get the engine, now it's got from the variables. 
* `engine` is required in app-interface 
* now it's dropped in the terraform object instead of in the input data. 

