### PR TITLE
Drop support for blue_green_update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/redhat-services-prod/app-sre-tenant/er-base-terraform-main/er-base-terraform-main:tf-1.6.6-py-3.12-v0.3.4-1@sha256:1579e58702182a02b55a0841254d188a6b99ff42c774279890567338c863a31b AS base
 # keep in sync with pyproject.toml
-LABEL konflux.additional-tags="0.6.1"
+LABEL konflux.additional-tags="0.6.2"
 
 FROM base AS builder
 COPY --from=ghcr.io/astral-sh/uv:0.5.25@sha256:a73176b27709bff700a1e3af498981f31a83f27552116f21ae8371445f0be710 /uv /bin/uv

--- a/er_aws_rds/input.py
+++ b/er_aws_rds/input.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Any, Literal
+from typing import Any, Literal, Self
 
 from external_resources_io.input import AppInterfaceProvision
 from pydantic import (
@@ -193,7 +193,7 @@ class Rds(RdsAppInterface):
         return self.name
 
     @model_validator(mode="after")
-    def az_belongs_to_region(self) -> "Rds":
+    def az_belongs_to_region(self) -> Self:
         """Check if a the AZ belongs to a region"""
         if self.availability_zone:
             az_region = self.availability_zone[:-1]
@@ -207,14 +207,14 @@ class Rds(RdsAppInterface):
         return self
 
     @model_validator(mode="after")
-    def unset_az_if_multi_region(self) -> "Rds":
+    def unset_az_if_multi_region(self) -> Self:
         """Remove az for multi_region instances"""
         if self.multi_az:
             self.availability_zone = None
         return self
 
     @model_validator(mode="after")
-    def unset_replica_or_snapshot_not_allowed_attrs(self) -> "Rds":
+    def unset_replica_or_snapshot_not_allowed_attrs(self) -> Self:
         """
         Some attributes are not allowed if the instance is a read replica or is created from a snapshot.
 
@@ -228,7 +228,7 @@ class Rds(RdsAppInterface):
         return self
 
     @model_validator(mode="after")
-    def replication(self) -> "Rds":
+    def replication(self) -> Self:
         """replica_source and replicate_source_db are mutually excluive"""
         if not self.replica_source:
             return self
@@ -257,7 +257,7 @@ class Rds(RdsAppInterface):
         return self
 
     @model_validator(mode="after")
-    def validate_parameter_group_parameters(self) -> "Rds":
+    def validate_parameter_group_parameters(self) -> Self:
         """Validate that every parameter complies with our requirements"""
         if not self.parameter_group:
             return self
@@ -271,7 +271,7 @@ class Rds(RdsAppInterface):
         return self
 
     @model_validator(mode="after")
-    def parameter_groups(self) -> "Rds":
+    def parameter_groups(self) -> Self:
         """
         Sets the right parameter group names. The instance identifier is used as prefix on each pg.
 
@@ -317,7 +317,7 @@ class Rds(RdsAppInterface):
         return self.replica_source is not None or self.replicate_source_db is not None
 
     @model_validator(mode="after")
-    def enhanced_monitoring_attributes(self) -> "Rds":
+    def enhanced_monitoring_attributes(self) -> Self:
         """
         Enhanced monitoring validation:
 
@@ -340,14 +340,14 @@ class Rds(RdsAppInterface):
         return self
 
     @model_validator(mode="after")
-    def kms_key_id_remove_alias_prefix(self) -> "Rds":
+    def kms_key_id_remove_alias_prefix(self) -> Self:
         """Remove alias prefix from kms_key_id"""
         if self.kms_key_id:
             self.kms_key_id = self.kms_key_id.removeprefix("alias/")
         return self
 
     @model_validator(mode="after")
-    def _validate_blue_green_update(self) -> "Rds":
+    def _validate_blue_green_update(self) -> Self:
         if self.blue_green_update and self.blue_green_update.enabled:
             raise ValueError(
                 "blue_green_update is not supported, use blue_green_deployment instead"

--- a/er_aws_rds/input.py
+++ b/er_aws_rds/input.py
@@ -347,14 +347,10 @@ class Rds(RdsAppInterface):
         return self
 
     @model_validator(mode="after")
-    def blue_green_update_requirements(self) -> "Rds":
-        if (
-            self.blue_green_update
-            and self.blue_green_update.enabled
-            and self.snapshot_identifier
-        ):
+    def _validate_blue_green_update(self) -> "Rds":
+        if self.blue_green_update and self.blue_green_update.enabled:
             raise ValueError(
-                "Blue/Green updates can not be enabled when snapshot_identifier is set"
+                "blue_green_update is not supported, use blue_green_deployment instead"
             )
         return self
 

--- a/module/basic_instance.tftest.hcl
+++ b/module/basic_instance.tftest.hcl
@@ -21,7 +21,6 @@ variables {
     performance_insights_enabled = true
     deletion_protection          = true
     ca_cert_identifier           = "rds-ca-rsa2048-g1"
-    blue_green_update            = { enabled = true }
     db_name                      = "custom_database"
   }
 

--- a/module/main.tf
+++ b/module/main.tf
@@ -86,20 +86,14 @@ resource "aws_db_event_subscription" "this" {
 }
 
 resource "aws_db_instance" "this" {
-  allocated_storage           = try(var.rds_instance.allocated_storage, null)
-  allow_major_version_upgrade = try(var.rds_instance.allow_major_version_upgrade, null)
-  apply_immediately           = try(var.rds_instance.apply_immediately, null)
-  auto_minor_version_upgrade  = try(var.rds_instance.auto_minor_version_upgrade, null)
-  availability_zone           = try(var.rds_instance.availability_zone, null)
-  backup_retention_period     = try(var.rds_instance.backup_retention_period, null)
-  backup_target               = try(var.rds_instance.backup_target, null)
-  backup_window               = try(var.rds_instance.backup_window, null)
-  dynamic "blue_green_update" {
-    for_each = try(length(var.rds_instance.blue_green_update), 0) > 0 ? [var.rds_instance.blue_green_update.enabled] : []
-    content {
-      enabled = try(var.rds_instance.blue_green_update.enabled, null)
-    }
-  }
+  allocated_storage                     = try(var.rds_instance.allocated_storage, null)
+  allow_major_version_upgrade           = try(var.rds_instance.allow_major_version_upgrade, null)
+  apply_immediately                     = try(var.rds_instance.apply_immediately, null)
+  auto_minor_version_upgrade            = try(var.rds_instance.auto_minor_version_upgrade, null)
+  availability_zone                     = try(var.rds_instance.availability_zone, null)
+  backup_retention_period               = try(var.rds_instance.backup_retention_period, null)
+  backup_target                         = try(var.rds_instance.backup_target, null)
+  backup_window                         = try(var.rds_instance.backup_window, null)
   ca_cert_identifier                    = try(var.rds_instance.ca_cert_identifier, null)
   character_set_name                    = try(var.rds_instance.character_set_name, null)
   copy_tags_to_snapshot                 = try(var.rds_instance.copy_tags_to_snapshot, null)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-aws-rds"
-version = "0.6.1"
+version = "0.6.2"
 description = "ERv2 module for managing AWS rds instances"
 authors = [{ name = "AppSRE", email = "sd-app-sre@redhat.com" }]
 license = { text = "Apache 2.0" }

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -280,3 +280,13 @@ def test_timeouts() -> None:
     model = AppInterfaceInput.model_validate(mod_input)
     assert model.data.timeouts is not None
     assert model.data.timeouts.create == "60m"
+
+
+def test_validate_blue_green_update() -> None:
+    """Test blue_green_update"""
+    mod_input = input_data({"data": {"blue_green_update": {"enabled": True}}})
+    with pytest.raises(
+        ValidationError,
+        match=r"blue_green_update is not supported, use blue_green_deployment instead",
+    ):
+        AppInterfaceInput.model_validate(mod_input)

--- a/uv.lock
+++ b/uv.lock
@@ -99,7 +99,7 @@ wheels = [
 
 [[package]]
 name = "er-aws-rds"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Drop support for `blue_green_update`, use `blue_green_deployment` instead.

[APPSRE-11434](https://issues.redhat.com/browse/APPSRE-11434)

This pull request includes several changes to various files, primarily focusing on updating labels and version numbers, modifying type hints in the `er_aws_rds/input.py` file, and removing the `blue_green_update` feature. Additionally, a new test has been added to validate the removal of `blue_green_update`.

### Version and Label Updates:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L3-R3): Updated `konflux.additional-tags` label from "0.6.1" to "0.6.2".
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Updated project version from "0.6.1" to "0.6.2".

### Type Hint Modifications:
* [`er_aws_rds/input.py`](diffhunk://#diff-fa4b05ce58b400425e2e210a5d5965854fe8c2eeb2490152b8e3774a25f1e7e8L2-R2): Changed return type hints from `"Rds"` to `Self` in multiple methods to improve type consistency. [[1]](diffhunk://#diff-fa4b05ce58b400425e2e210a5d5965854fe8c2eeb2490152b8e3774a25f1e7e8L2-R2) [[2]](diffhunk://#diff-fa4b05ce58b400425e2e210a5d5965854fe8c2eeb2490152b8e3774a25f1e7e8L196-R196) [[3]](diffhunk://#diff-fa4b05ce58b400425e2e210a5d5965854fe8c2eeb2490152b8e3774a25f1e7e8L210-R217) [[4]](diffhunk://#diff-fa4b05ce58b400425e2e210a5d5965854fe8c2eeb2490152b8e3774a25f1e7e8L231-R231) [[5]](diffhunk://#diff-fa4b05ce58b400425e2e210a5d5965854fe8c2eeb2490152b8e3774a25f1e7e8L260-R260) [[6]](diffhunk://#diff-fa4b05ce58b400425e2e210a5d5965854fe8c2eeb2490152b8e3774a25f1e7e8L274-R274) [[7]](diffhunk://#diff-fa4b05ce58b400425e2e210a5d5965854fe8c2eeb2490152b8e3774a25f1e7e8L320-R320) [[8]](diffhunk://#diff-fa4b05ce58b400425e2e210a5d5965854fe8c2eeb2490152b8e3774a25f1e7e8L343-R353)

### Feature Removal:
* [`module/basic_instance.tftest.hcl`](diffhunk://#diff-d2112c24885c8c94d346aad30ec5131b854e0df74a963d86e206186a1821114eL24): Removed the `blue_green_update` variable.
* [`module/main.tf`](diffhunk://#diff-1bbb738cea2804e60d73449f03fc14a9cbbda5c7df1773e8726fa16dfa0f6af2L97-L102): Removed the `blue_green_update` dynamic block.

### Test Additions:
* [`tests/test_input_validation.py`](diffhunk://#diff-08fc3d02ead45670ed98689a721d71d5e8135f5bdf27a1bc64f3800944694c81R283-R292): Added a new test `test_validate_blue_green_update` to ensure `blue_green_update` is not supported and raises the appropriate validation error.