### PR TITLE
Support blue/green deployment for replicas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/redhat-services-prod/app-sre-tenant/er-base-terraform-main/er-base-terraform-main:tf-1.6.6-py-3.12-v0.3.4-1@sha256:1579e58702182a02b55a0841254d188a6b99ff42c774279890567338c863a31b AS base
 # keep in sync with pyproject.toml
-LABEL konflux.additional-tags="0.6.2"
+LABEL konflux.additional-tags="0.6.3"
 
 FROM base AS builder
 COPY --from=ghcr.io/astral-sh/uv:0.5.25@sha256:a73176b27709bff700a1e3af498981f31a83f27552116f21ae8371445f0be710 /uv /bin/uv

--- a/er_aws_rds/input.py
+++ b/er_aws_rds/input.py
@@ -234,6 +234,11 @@ class Rds(RdsAppInterface):
         if not self.replica_source:
             return self
 
+        if self.replica_source.blue_green_deployment_enabled and self.parameter_group:
+            raise ValueError(
+                "parameter_group is not supported when replica_source has blue_green_deployment enabled"
+            )
+
         if self.replicate_source_db:
             msg = "Only one of replicate_source_db or replica_source can be defined"
             raise ValueError(msg)

--- a/er_aws_rds/input.py
+++ b/er_aws_rds/input.py
@@ -177,6 +177,7 @@ class Rds(RdsAppInterface):
     parameter_group_name: str | None = None
     timeouts: DBInstanceTimeouts | None = None
     blue_green_update: BlueGreenUpdate | None = None
+    deletion_protection: bool | None = None
 
     @property
     def enhanced_monitoring_role_name(self) -> str:
@@ -234,10 +235,15 @@ class Rds(RdsAppInterface):
         if not self.replica_source:
             return self
 
-        if self.replica_source.blue_green_deployment_enabled and self.parameter_group:
-            raise ValueError(
-                "parameter_group is not supported when replica_source has blue_green_deployment enabled"
-            )
+        if self.replica_source.blue_green_deployment_enabled:
+            if self.parameter_group:
+                raise ValueError(
+                    "parameter_group is not supported when replica_source has blue_green_deployment enabled"
+                )
+            if self.deletion_protection:
+                raise ValueError(
+                    "deletion_protection must be disabled when replica_source has blue_green_deployment enabled"
+                )
 
         if self.replicate_source_db:
             msg = "Only one of replicate_source_db or replica_source can be defined"

--- a/er_aws_rds/input.py
+++ b/er_aws_rds/input.py
@@ -72,6 +72,7 @@ class ReplicaSource(BaseModel):
 
     region: str
     identifier: str
+    blue_green_deployment_enabled: bool
 
 
 class BlueGreenDeploymentTarget(BaseModel):

--- a/er_aws_rds/input.py
+++ b/er_aws_rds/input.py
@@ -235,16 +235,6 @@ class Rds(RdsAppInterface):
         if not self.replica_source:
             return self
 
-        if self.replica_source.blue_green_deployment_enabled:
-            if self.parameter_group:
-                raise ValueError(
-                    "parameter_group is not supported when replica_source has blue_green_deployment enabled"
-                )
-            if self.deletion_protection:
-                raise ValueError(
-                    "deletion_protection must be disabled when replica_source has blue_green_deployment enabled"
-                )
-
         if self.replicate_source_db:
             msg = "Only one of replicate_source_db or replica_source can be defined"
             raise ValueError(msg)
@@ -363,6 +353,23 @@ class Rds(RdsAppInterface):
         if self.blue_green_update and self.blue_green_update.enabled:
             raise ValueError(
                 "blue_green_update is not supported, use blue_green_deployment instead"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_blue_green_deployment_for_replica(self) -> Self:
+        if self.replica_source and self.replica_source.blue_green_deployment_enabled:
+            if self.parameter_group:
+                raise ValueError(
+                    "parameter_group is not supported when replica_source has blue_green_deployment enabled"
+                )
+            if self.deletion_protection:
+                raise ValueError(
+                    "deletion_protection must be disabled when replica_source has blue_green_deployment enabled"
+                )
+        if self.is_read_replica and self.blue_green_deployment:
+            raise ValueError(
+                "blue_green_deployment is not supported for replica instance"
             )
         return self
 

--- a/hooks/pre_run.py
+++ b/hooks/pre_run.py
@@ -35,6 +35,7 @@ def main() -> None:
             sys.exit(EXIT_OK)
         case (
             State.INIT
+            | State.REPLICA_SOURCE_ENABLED
             | State.PROVISIONING
             | State.AVAILABLE
             | State.SWITCHOVER_IN_PROGRESS

--- a/hooks/utils/blue_green_deployment_manager.py
+++ b/hooks/utils/blue_green_deployment_manager.py
@@ -52,6 +52,11 @@ class BlueGreenDeploymentManager:
 
     def run(self) -> State:
         """Run Blue/Green Deployment Manager"""
+        if (
+            replica_source := self.app_interface_input.data.replica_source
+        ) and replica_source.blue_green_deployment_enabled:
+            self.logger.info("blue_green_deployment in replica_source enabled.")
+            return State.REPLICA_SOURCE_ENABLED
         config = self.app_interface_input.data.blue_green_deployment
         if config is None or not config.enabled:
             self.logger.info("blue_green_deployment not enabled.")

--- a/hooks/utils/blue_green_deployment_manager.py
+++ b/hooks/utils/blue_green_deployment_manager.py
@@ -23,6 +23,7 @@ from hooks.utils.models import (
     CreateAction,
     DeleteAction,
     DeleteSourceDBInstanceAction,
+    NoOpAction,
     State,
     SwitchoverAction,
     WaitForAvailableAction,
@@ -57,14 +58,20 @@ class BlueGreenDeploymentManager:
         ) and replica_source.blue_green_deployment_enabled:
             self.logger.info("blue_green_deployment in replica_source enabled.")
             return State.REPLICA_SOURCE_ENABLED
+
         config = self.app_interface_input.data.blue_green_deployment
         if config is None or not config.enabled:
             self.logger.info("blue_green_deployment not enabled.")
             return State.NOT_ENABLED
+
         self.model = self._build_model(config)
         actions = self.model.plan_actions()
-        if not actions:
+        if all(action.type == ActionType.NO_OP for action in actions):
             self.logger.info("No changes for Blue/Green Deployment.")
+            for action in actions:
+                self.model.state = action.next_state
+            return self.model.state
+
         for action in actions:
             self.logger.info(f"Action {action.type}: {action.model_dump_json()}")
             if not self.dry_run:
@@ -181,6 +188,7 @@ class BlueGreenDeploymentManager:
             ActionType.DELETE: self._handle_delete,
             ActionType.DELETE_WITHOUT_SWITCHOVER: self._handle_delete_without_switchover,
             ActionType.WAIT_FOR_DELETED: self._handle_wait_for_delete,
+            ActionType.NO_OP: self._handle_no_op,
         }
 
     def _handle_create(self, action: CreateAction) -> None:
@@ -273,3 +281,7 @@ class BlueGreenDeploymentManager:
 
     def _handle_wait_for_delete(self, _: WaitForDeletedAction) -> None:
         wait_for(self._wait_for_delete_condition_condition, logger=self.logger)
+
+    @staticmethod
+    def _handle_no_op(_: NoOpAction) -> None:
+        return

--- a/hooks/utils/blue_green_deployment_model.py
+++ b/hooks/utils/blue_green_deployment_model.py
@@ -191,8 +191,7 @@ class BlueGreenDeploymentModel(BaseModel):
             next_state = action.next_state
             if next_state not in allowed_next_states:
                 raise ValueError(f"Invalid next state: {next_state} for state: {state}")
-            if action.type != ActionType.NO_OP:
-                actions.append(action)
+            actions.append(action)
             state = next_state
         return actions
 

--- a/hooks/utils/models.py
+++ b/hooks/utils/models.py
@@ -46,6 +46,7 @@ class State(StrEnum):
     """State Enum"""
 
     INIT = "init"
+    REPLICA_SOURCE_ENABLED = "replica_source_enabled"
     NOT_ENABLED = "not_enabled"
     PROVISIONING = "provisioning"
     AVAILABLE = "available"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-aws-rds"
-version = "0.6.2"
+version = "0.6.3"
 description = "ERv2 module for managing AWS rds instances"
 authors = [{ name = "AppSRE", email = "sd-app-sre@redhat.com" }]
 license = { text = "Apache 2.0" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,7 @@ DEFAULT_DATA = {
         "apply_immediately": True,
         "identifier": "test-rds",
         "parameter_group": DEFAULT_PARAMETER_GROUP,
+        "deletion_protection": False,
         "output_resource_name": "test-rds-credentials",
         "ca_cert": {
             "path": "app-interface/global/rds-ca-cert",

--- a/tests/test_blue_green_deployment_manager.py
+++ b/tests/test_blue_green_deployment_manager.py
@@ -1114,7 +1114,8 @@ def test_run_for_read_replica_has_blue_green_deployment_enabled(
                 "identifier": "test-rds-source",
                 "region": "us-east-1",
                 "blue_green_deployment_enabled": True,
-            }
+            },
+            "parameter_group": None,
         }
     }
     manager = BlueGreenDeploymentManager(

--- a/tests/test_blue_green_deployment_manager.py
+++ b/tests/test_blue_green_deployment_manager.py
@@ -948,7 +948,7 @@ def test_run_when_no_changes_and_no_blue_green_deployment(
 
     state = manager.run()
 
-    assert state == State.INIT
+    assert state == State.NO_OP
     mock_aws_api.get_db_instance.assert_called_once_with("test-rds")
     mock_aws_api.get_blue_green_deployment.assert_called_once_with("test-rds")
     mock_logging.info.assert_called_once_with("No changes for Blue/Green Deployment.")

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -290,3 +290,22 @@ def test_validate_blue_green_update() -> None:
         match=r"blue_green_update is not supported, use blue_green_deployment instead",
     ):
         AppInterfaceInput.model_validate(mod_input)
+
+
+def test_validate_replica_source_with_parameter_group() -> None:
+    """Test that replica_source with parameter_group is not allowed"""
+    mod_input = input_data({
+        "data": {
+            "replica_source": {
+                "identifier": "test-rds-source",
+                "region": "us-east-1",
+                "blue_green_deployment_enabled": True,
+            },
+            "parameter_group": DEFAULT_PARAMETER_GROUP,
+        }
+    })
+    with pytest.raises(
+        ValidationError,
+        match=r".*parameter_group is not supported when replica_source has blue_green_deployment enabled.*",
+    ):
+        AppInterfaceInput.model_validate(mod_input)

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -309,3 +309,23 @@ def test_validate_replica_source_with_parameter_group() -> None:
         match=r".*parameter_group is not supported when replica_source has blue_green_deployment enabled.*",
     ):
         AppInterfaceInput.model_validate(mod_input)
+
+
+def test_validate_replica_source_with_deletion_protection() -> None:
+    """Test that replica_source with deletion_protection"""
+    mod_input = input_data({
+        "data": {
+            "replica_source": {
+                "identifier": "test-rds-source",
+                "region": "us-east-1",
+                "blue_green_deployment_enabled": True,
+            },
+            "parameter_group": None,
+            "deletion_protection": True,
+        }
+    })
+    with pytest.raises(
+        ValidationError,
+        match=r".*deletion_protection must be disabled when replica_source has blue_green_deployment enabled.*",
+    ):
+        AppInterfaceInput.model_validate(mod_input)

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -292,8 +292,8 @@ def test_validate_blue_green_update() -> None:
         AppInterfaceInput.model_validate(mod_input)
 
 
-def test_validate_replica_source_with_parameter_group() -> None:
-    """Test that replica_source with parameter_group is not allowed"""
+def test_validate_blue_green_deployment_for_replica_with_parameter_group() -> None:
+    """Test blue_green_deployment for replica with parameter group"""
     mod_input = input_data({
         "data": {
             "replica_source": {
@@ -311,8 +311,8 @@ def test_validate_replica_source_with_parameter_group() -> None:
         AppInterfaceInput.model_validate(mod_input)
 
 
-def test_validate_replica_source_with_deletion_protection() -> None:
-    """Test that replica_source with deletion_protection"""
+def test_validate_blue_green_deployment_for_replica_with_deletion_protection() -> None:
+    """Test blue_green_deployment for replica with deletion protection"""
     mod_input = input_data({
         "data": {
             "replica_source": {
@@ -327,5 +327,28 @@ def test_validate_replica_source_with_deletion_protection() -> None:
     with pytest.raises(
         ValidationError,
         match=r".*deletion_protection must be disabled when replica_source has blue_green_deployment enabled.*",
+    ):
+        AppInterfaceInput.model_validate(mod_input)
+
+
+def test_validate_blue_green_deployment_for_replica() -> None:
+    """Test that blue_green_deployment is not supported for replica instance"""
+    mod_input = input_data({
+        "data": {
+            "replica_source": {
+                "identifier": "test-rds-source",
+                "region": "us-east-1",
+                "blue_green_deployment_enabled": False,
+            },
+            "blue_green_deployment": {
+                "enabled": False,
+                "switchover": False,
+                "delete": False,
+            },
+        }
+    })
+    with pytest.raises(
+        ValidationError,
+        match=r".*blue_green_deployment is not supported for replica instance.*",
     ):
         AppInterfaceInput.model_validate(mod_input)

--- a/tests/test_pre_run.py
+++ b/tests/test_pre_run.py
@@ -59,6 +59,8 @@ def mock_is_dry_run() -> Iterator[Mock]:
         (False, State.DELETING, 42),
         (True, State.NO_OP, 0),
         (False, State.NO_OP, 0),
+        (True, State.REPLICA_SOURCE_ENABLED, 42),
+        (False, State.REPLICA_SOURCE_ENABLED, 42),
     ],
 )
 def test_pre_hook(  # noqa: PLR0913

--- a/uv.lock
+++ b/uv.lock
@@ -99,7 +99,7 @@ wheels = [
 
 [[package]]
 name = "er-aws-rds"
-version = "0.6.2"
+version = "0.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
If the instance is a replica, then validate:

* no `parameter_group` specified, because blue/green deployment only support one, replica shouldn't set parameter group, not set means to use source instance by AWS
* `deletion_protection` should be disabled, because blue/green deployment need to delete instance

Also skip terraform steps if source has `blue_green_deployment` enabled to avoid conflicts.

Need to promote same time as https://github.com/app-sre/qontract-reconcile/pull/4913

[APPSRE-11434](https://issues.redhat.com/browse/APPSRE-11434)