### PR TITLE
Deprecate old parameter group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/redhat-services-prod/app-sre-tenant/er-base-terraform-main/er-base-terraform-main:tf-1.6.6-py-3.12-v0.3.4-1@sha256:1579e58702182a02b55a0841254d188a6b99ff42c774279890567338c863a31b AS base
 # keep in sync with pyproject.toml
-LABEL konflux.additional-tags="0.6.4"
+LABEL konflux.additional-tags="0.6.5"
 
 FROM base AS builder
 COPY --from=ghcr.io/astral-sh/uv:0.5.25@sha256:a73176b27709bff700a1e3af498981f31a83f27552116f21ae8371445f0be710 /uv /bin/uv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-aws-rds"
-version = "0.6.4"
+version = "0.6.5"
 description = "ERv2 module for managing AWS rds instances"
 authors = [{ name = "AppSRE", email = "sd-app-sre@redhat.com" }]
 license = { text = "Apache 2.0" }

--- a/tests/test_input_terraform.py
+++ b/tests/test_input_terraform.py
@@ -7,15 +7,6 @@ from .conftest import DEFAULT_PARAMETER_GROUP, input_object
 EXPECTED_DEFAULT_PARAMETER_GROUP = DEFAULT_PARAMETER_GROUP | {
     "name": "test-rds-test-pg",
 }
-OLD_PARAMETER_GROUP = {
-    "name": "postgres-15",
-    "family": "postgres15",
-    "description": "Parameter Group for PostgreSQL 15",
-    "parameters": [],
-}
-EXPECTED_OLD_PARAMETER_GROUP = OLD_PARAMETER_GROUP | {
-    "name": "test-rds-postgres-15",
-}
 BLUE_GREEN_DEPLOYMENT_PARAMETER_GROUP = {
     "name": "postgres-16",
     "family": "postgres16",
@@ -32,17 +23,10 @@ EXPECTED_BLUE_GREEN_DEPLOYMENT_PARAMETER_GROUP = (
 
 def test_parameter_group_names() -> None:
     """Ensure terraform model gets the right parameter group names"""
-    model = input_object({
-        "data": {
-            "old_parameter_group": OLD_PARAMETER_GROUP,
-        }
-    })
+    model = input_object()
     tf_model = TerraformModuleData(ai_input=model).model_dump()
 
-    assert tf_model["parameter_groups"] == [
-        EXPECTED_DEFAULT_PARAMETER_GROUP,
-        EXPECTED_OLD_PARAMETER_GROUP,
-    ]
+    assert tf_model["parameter_groups"] == [EXPECTED_DEFAULT_PARAMETER_GROUP]
 
 
 @pytest.mark.parametrize("enabled", [True, False])
@@ -50,7 +34,6 @@ def test_parameter_groups_with_blue_green_deployment(*, enabled: bool) -> None:
     """Test parameter groups with blue-green deployment"""
     model = input_object({
         "data": {
-            "old_parameter_group": OLD_PARAMETER_GROUP,
             "blue_green_deployment": {
                 "enabled": enabled,
                 "switchover": False,
@@ -65,7 +48,6 @@ def test_parameter_groups_with_blue_green_deployment(*, enabled: bool) -> None:
 
     assert tf_model["parameter_groups"] == [
         EXPECTED_DEFAULT_PARAMETER_GROUP,
-        EXPECTED_OLD_PARAMETER_GROUP,
         EXPECTED_BLUE_GREEN_DEPLOYMENT_PARAMETER_GROUP,
     ]
 
@@ -74,7 +56,6 @@ def test_parameter_groups_when_blue_green_deployment_has_duplicate() -> None:
     """Test parameter groups when blue-green deployment has duplicate"""
     model = input_object({
         "data": {
-            "old_parameter_group": OLD_PARAMETER_GROUP,
             "parameter_group": DEFAULT_PARAMETER_GROUP,
             "blue_green_deployment": {
                 "enabled": False,
@@ -88,7 +69,4 @@ def test_parameter_groups_when_blue_green_deployment_has_duplicate() -> None:
     })
     tf_model = TerraformModuleData(ai_input=model).model_dump()
 
-    assert tf_model["parameter_groups"] == [
-        EXPECTED_DEFAULT_PARAMETER_GROUP,
-        EXPECTED_OLD_PARAMETER_GROUP,
-    ]
+    assert tf_model["parameter_groups"] == [EXPECTED_DEFAULT_PARAMETER_GROUP]

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -58,44 +58,6 @@ def test_parameter_group_name_without_pg_name() -> None:
     assert model.data.parameter_group.name == f"{model.data.identifier}-pg"
 
 
-def test_parameter_group_name_along_old_parameter_group_1() -> None:
-    """Test correct parameter group names are set"""
-    mod_input = input_data({
-        "data": {
-            "old_parameter_group": {
-                "name": "postgres-16",
-                "family": "postgres16",
-                "description": "Parameter Group for PostgreSQL 16",
-                "parameters": [],
-            }
-        }
-    })
-    model = AppInterfaceInput.model_validate(mod_input)
-    assert model.data.parameter_group is not None
-    assert model.data.old_parameter_group is not None
-    assert model.data.parameter_group.name == f"{model.data.identifier}-test-pg"
-    assert model.data.old_parameter_group.name == f"{model.data.identifier}-postgres-16"
-
-
-def test_parameter_group_along_old_parameter_group_without_names() -> None:
-    """Test correct parameter group names are set"""
-    mod_input = input_data({
-        "data": {
-            "parameter_group": {"name": None},
-            "old_parameter_group": {
-                "family": "postgres16",
-                "description": "Parameter Group for PostgreSQL 16",
-                "parameters": [],
-            },
-        }
-    })
-    with pytest.raises(
-        ValidationError,
-        match=r".*Parameter group and old parameter group have the same name.*",
-    ):
-        AppInterfaceInput.model_validate(mod_input)
-
-
 def test_blue_green_deployment_parameter_group_default_name() -> None:
     """Test Blue/Green Deployment parameter group default name"""
     mod_input = input_data({

--- a/uv.lock
+++ b/uv.lock
@@ -99,7 +99,7 @@ wheels = [
 
 [[package]]
 name = "er-aws-rds"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
`old_parameter_group` is no longer needed

[APPSRE-11657](https://issues.redhat.com/browse/APPSRE-11657)