### PR TITLE
Validate parameter group changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/redhat-services-prod/app-sre-tenant/er-base-terraform-main/er-base-terraform-main:tf-1.6.6-py-3.12-v0.3.4-1@sha256:1579e58702182a02b55a0841254d188a6b99ff42c774279890567338c863a31b AS base
 # keep in sync with pyproject.toml
-LABEL konflux.additional-tags="0.6.6"
+LABEL konflux.additional-tags="0.6.7"
 
 FROM base AS builder
 COPY --from=ghcr.io/astral-sh/uv:0.6.12@sha256:515b886e8eb99bcf9278776d8ea41eb4553a794195ef5803aa7ca6258653100d /uv /bin/uv

--- a/er_aws_rds/errors.py
+++ b/er_aws_rds/errors.py
@@ -1,2 +1,0 @@
-class RDSLogicalReplicationError(Exception):
-    """Custom exception for RDS logical replication setting errors"""

--- a/er_aws_rds/input.py
+++ b/er_aws_rds/input.py
@@ -11,8 +11,6 @@ from pydantic import (
     model_validator,
 )
 
-from er_aws_rds.errors import RDSLogicalReplicationError
-
 ENHANCED_MONITORING_ROLE_NAME_MAX_LENGTH = 64
 
 
@@ -262,20 +260,6 @@ class Rds(RdsAppInterface):
 
         # No backup for replicas
         self.backup_retention_period = 0
-        return self
-
-    @model_validator(mode="after")
-    def validate_parameter_group_parameters(self) -> Self:
-        """Validate that every parameter complies with our requirements"""
-        if not self.parameter_group:
-            return self
-        for parameter in self.parameter_group.parameters or []:
-            if (
-                parameter.name == "rds.logical_replication"
-                and parameter.apply_method != "pending-reboot"
-            ):
-                msg = "rds.logical_replication must be set to pending-reboot"
-                raise RDSLogicalReplicationError(msg)
         return self
 
     @model_validator(mode="after")

--- a/hooks/post_plan.py
+++ b/hooks/post_plan.py
@@ -182,6 +182,9 @@ class RDSPlanValidator:
             for parameter in change.after.get("parameter") or []
         }
 
+        if not after_parameter_by_name:
+            return
+
         default_parameter_by_name = self.aws_api.get_engine_default_parameters(
             change.after["family"],
             list(after_parameter_by_name.keys()),

--- a/hooks/post_plan.py
+++ b/hooks/post_plan.py
@@ -218,9 +218,10 @@ class RDSPlanValidator:
         before_parameter_by_name: dict[str, Parameter],
         after_parameter_by_name: dict[str, Parameter],
     ) -> None:
+        common_names = before_parameter_by_name.keys() & after_parameter_by_name.keys()
         apply_method_change_only_parameter_names = [
             name
-            for name in before_parameter_by_name.keys() & after_parameter_by_name.keys()
+            for name in common_names
             if self._is_apply_method_change_only(
                 before_parameter_by_name[name],
                 after_parameter_by_name[name],
@@ -240,13 +241,13 @@ class RDSPlanValidator:
         default_parameter_by_name: dict[str, ParameterOutputTypeDef],
         after_parameter_by_name: dict[str, Parameter],
     ) -> None:
+        common_names = default_parameter_by_name.keys() & after_parameter_by_name.keys()
         immediate_on_static_parameter_names = [
-            parameter_name
-            for parameter_name, parameter in after_parameter_by_name.items()
+            name
+            for name in common_names
             if (
-                parameter.apply_method == "immediate"
-                and (default_parameter := default_parameter_by_name.get(parameter_name))
-                and default_parameter.get("ApplyType") == "static"
+                after_parameter_by_name[name].apply_method == "immediate"
+                and default_parameter_by_name[name].get("ApplyType") == "static"
             )
         ]
         if immediate_on_static_parameter_names:

--- a/hooks/post_plan.py
+++ b/hooks/post_plan.py
@@ -229,9 +229,10 @@ class RDSPlanValidator:
         if apply_method_change_only_parameter_names:
             parameters = ", ".join(apply_method_change_only_parameter_names)
             self.errors.append(
-                "Problematic plan changes for parameter group detected, "
-                f"apply_method only changes are not allowed, parameters: {parameters}, "
-                "checkout https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group#problematic-plan-changes"
+                f"Problematic plan changes for parameter group detected for parameters: {parameters}. "
+                "Parameter with only apply_method toggled while value is same as before or default is not allowed, "
+                "remove the parameter OR change value OR align apply_method with AWS default pending-reboot, "
+                "checkout details at https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group#problematic-plan-changes"
             )
 
     def _validate_apply_method_with_apply_type(

--- a/hooks/utils/aws_api.py
+++ b/hooks/utils/aws_api.py
@@ -13,6 +13,7 @@ from mypy_boto3_rds.type_defs import (
     BlueGreenDeploymentTypeDef,
     DBInstanceTypeDef,
     DBParameterGroupTypeDef,
+    DescribeEngineDefaultParametersMessageTypeDef,
     ParameterOutputTypeDef,
     UpgradeTargetTypeDef,
 )
@@ -111,6 +112,28 @@ class AWSApi:
             ],
         )
         return {item["ParameterName"]: item for item in data["Parameters"] or []}
+
+    def get_engine_default_parameters(
+        self,
+        parameter_group_family: str,
+        parameter_names: list[str],
+    ) -> dict[str, ParameterOutputTypeDef]:
+        """Get engine default parameters"""
+        kwargs: DescribeEngineDefaultParametersMessageTypeDef = {
+            "DBParameterGroupFamily": parameter_group_family,
+        }
+        if parameter_names:
+            kwargs["Filters"] = [
+                {
+                    "Name": "parameter-name",
+                    "Values": parameter_names,
+                }
+            ]
+        data = self.rds_client.describe_engine_default_parameters(**kwargs)
+        return {
+            item["ParameterName"]: item
+            for item in data.get("EngineDefaults", {}).get("Parameters") or []
+        }
 
     def get_db_instance(self, identifier: str) -> DBInstanceTypeDef | None:
         """Get DB instance info"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-aws-rds"
-version = "0.6.6"
+version = "0.6.7"
 description = "ERv2 module for managing AWS rds instances"
 authors = [{ name = "AppSRE", email = "sd-app-sre@redhat.com" }]
 license = { text = "Apache 2.0" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from er_aws_rds.input import AppInterfaceInput
 
 def deep_merge(dict1: dict[str, Any], dict2: dict[str, Any]) -> dict[str, Any]:
     """Merge two dictionaries recursively"""
-    return dict1.copy() | {
+    return dict1 | {
         key: (
             deep_merge(dict1[key], value)
             if key in dict1 and isinstance(dict1[key], dict) and isinstance(value, dict)

--- a/tests/test_aws_api.py
+++ b/tests/test_aws_api.py
@@ -360,6 +360,39 @@ def test_get_db_parameters(mock_rds_client: Mock) -> None:
     )
 
 
+def test_get_engine_default_parameters(mock_rds_client: Mock) -> None:
+    """Test get_engine_default_parameters"""
+    aws_api = AWSApi()
+    expected_parameter = {
+        "ParameterName": "rds.force_ssl",
+        "ParameterValue": "1",
+        "ApplyMethod": "pending-reboot",
+    }
+    mock_rds_client.describe_engine_default_parameters.return_value = {
+        "EngineDefaults": {
+            "DBParameterGroupFamily": "postgres15",
+            "Parameters": [expected_parameter],
+        }
+    }
+    expected_result = {"rds.force_ssl": expected_parameter}
+
+    result = aws_api.get_engine_default_parameters(
+        parameter_group_family="postgres15",
+        parameter_names=["rds.force_ssl"],
+    )
+
+    assert result == expected_result
+    mock_rds_client.describe_engine_default_parameters.assert_called_once_with(
+        DBParameterGroupFamily="postgres15",
+        Filters=[
+            {
+                "Name": "parameter-name",
+                "Values": ["rds.force_ssl"],
+            }
+        ],
+    )
+
+
 def test_switchover_blue_green_deployment(mock_rds_client: Mock) -> None:
     """Test switchover_blue_green_deployment"""
     aws_api = AWSApi()

--- a/tests/test_blue_green_deployment_manager.py
+++ b/tests/test_blue_green_deployment_manager.py
@@ -96,8 +96,8 @@ def build_blue_green_deployment_data(
                 "delete": delete,
                 "target": target,
             },
-            **target,
         }
+        | target,
     }
 
 

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -1,7 +1,6 @@
 import pytest
 from pydantic_core import ValidationError
 
-from er_aws_rds.errors import RDSLogicalReplicationError
 from er_aws_rds.input import (
     ENHANCED_MONITORING_ROLE_NAME_MAX_LENGTH,
     AppInterfaceInput,
@@ -11,26 +10,6 @@ from er_aws_rds.input import (
 )
 
 from .conftest import DEFAULT_PARAMETER_GROUP, DEFAULT_TARGET, input_data
-
-
-def test_validate_parameter_rds_replication() -> None:
-    """Test that rds.logical_replication parameter must be set to 'pending-reboot'"""
-    # mod_input = input_data()
-    mod_input = input_data({
-        "data": {
-            "parameter_group": {
-                "parameters": [
-                    {
-                        "name": "rds.logical_replication",
-                        "value": "1",
-                        "apply_method": "immediate",
-                    }
-                ],
-            }
-        }
-    })
-    with pytest.raises(RDSLogicalReplicationError):
-        AppInterfaceInput.model_validate(mod_input)
 
 
 def test_parameter_value_as_string() -> None:

--- a/tests/test_plan_validation.py
+++ b/tests/test_plan_validation.py
@@ -277,67 +277,61 @@ def test_validate_no_changes_allow_delete_when_blue_green_deployment_enabled(
     assert errors == []
 
 
-def test_validate_parameter_group_with_apply_method_only_change_on_update(
-    mock_aws_api: Mock,
-) -> None:
-    """Test parameter group update validation for apply_only_change"""
-    mock_aws_api.return_value.get_engine_default_parameters.return_value = {
-        "rds.force_ssl": {
-            "ParameterName": "rds.force_ssl",
-            "ParameterValue": "1",
-        }
-    }
-    plan = Plan.model_validate({
-        "resource_changes": [
+@pytest.mark.parametrize(
+    ("action", "before", "after"),
+    [
+        (
+            "update",
             {
-                "type": "aws_db_parameter_group",
-                "change": {
-                    "actions": ["update"],
-                    "before": {
-                        "id": "test-rds-pg15",
-                        "name": "test-rds-pg15",
-                        "family": "postgres15",
-                        "parameter": [
-                            {
-                                "apply_method": "pending-reboot",
-                                "name": "rds.force_ssl",
-                                "value": "1",
-                            },
-                        ],
+                "id": "test-rds-pg15",
+                "name": "test-rds-pg15",
+                "family": "postgres15",
+                "parameter": [
+                    {
+                        "apply_method": "pending-reboot",
+                        "name": "rds.force_ssl",
+                        "value": "1",
                     },
-                    "after": {
-                        "id": "test-rds-pg15",
-                        "name": "test-rds-pg15",
-                        "family": "postgres15",
-                        "parameter": [
-                            {
-                                "apply_method": "immediate",
-                                "name": "rds.force_ssl",
-                                "value": "1",
-                            },
-                        ],
-                    },
-                    "after_unknown": {},
-                },
+                ],
             },
-        ]
-    })
-    validator = RDSPlanValidator(plan, input_object())
-
-    errors = validator.validate()
-
-    assert errors == [
-        "Problematic plan changes for parameter group detected for parameters: rds.force_ssl. "
-        "Parameter with only apply_method toggled while value is same as before or default is not allowed, "
-        "remove the parameter OR change value OR align apply_method with AWS default pending-reboot, "
-        "checkout details at https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group#problematic-plan-changes"
-    ]
-
-
-def test_validate_parameter_group_with_apply_method_only_change_on_create(
+            {
+                "id": "test-rds-pg15",
+                "name": "test-rds-pg15",
+                "family": "postgres15",
+                "parameter": [
+                    {
+                        "apply_method": "immediate",
+                        "name": "rds.force_ssl",
+                        "value": "1",
+                    },
+                ],
+            },
+        ),
+        (
+            "create",
+            None,
+            {
+                "id": "test-rds-pg15",
+                "name": "test-rds-pg15",
+                "family": "postgres15",
+                "parameter": [
+                    {
+                        "apply_method": "immediate",
+                        "name": "rds.force_ssl",
+                        "value": "1",
+                    },
+                ],
+            },
+        ),
+    ],
+)
+def test_validate_parameter_group_with_apply_method_only_change(
+    action: str,
+    before: dict[str, Any] | None,
+    after: dict[str, Any],
     mock_aws_api: Mock,
 ) -> None:
-    """Test parameter group create validation for apply_only_change"""
+    """Test parameter group validation for apply_method only change"""
     # ApplyMethod is pending-reboot in default parameter group
     # but the field is not returned in actual DescribeEngineDefaultParameters response
     mock_aws_api.return_value.get_engine_default_parameters.return_value = {
@@ -351,20 +345,9 @@ def test_validate_parameter_group_with_apply_method_only_change_on_create(
             {
                 "type": "aws_db_parameter_group",
                 "change": {
-                    "actions": ["create"],
-                    "before": None,
-                    "after": {
-                        "id": "test-rds-pg15",
-                        "name": "test-rds-pg15",
-                        "family": "postgres15",
-                        "parameter": [
-                            {
-                                "apply_method": "immediate",
-                                "name": "rds.force_ssl",
-                                "value": "1",
-                            },
-                        ],
-                    },
+                    "actions": [action],
+                    "before": before,
+                    "after": after,
                     "after_unknown": {},
                 },
             },

--- a/tests/test_plan_validation.py
+++ b/tests/test_plan_validation.py
@@ -327,9 +327,10 @@ def test_validate_parameter_group_with_apply_method_only_change_on_update(
     errors = validator.validate()
 
     assert errors == [
-        "Problematic plan changes for parameter group detected, "
-        "apply_method only changes are not allowed, parameters: rds.force_ssl, "
-        "checkout https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group#problematic-plan-changes"
+        "Problematic plan changes for parameter group detected for parameters: rds.force_ssl. "
+        "Parameter with only apply_method toggled while value is same as before or default is not allowed, "
+        "remove the parameter OR change value OR align apply_method with AWS default pending-reboot, "
+        "checkout details at https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group#problematic-plan-changes"
     ]
 
 
@@ -374,9 +375,10 @@ def test_validate_parameter_group_with_apply_method_only_change_on_create(
     errors = validator.validate()
 
     assert errors == [
-        "Problematic plan changes for parameter group detected, "
-        "apply_method only changes are not allowed, parameters: rds.force_ssl, "
-        "checkout https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group#problematic-plan-changes"
+        "Problematic plan changes for parameter group detected for parameters: rds.force_ssl. "
+        "Parameter with only apply_method toggled while value is same as before or default is not allowed, "
+        "remove the parameter OR change value OR align apply_method with AWS default pending-reboot, "
+        "checkout details at https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group#problematic-plan-changes"
     ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -99,7 +99,7 @@ wheels = [
 
 [[package]]
 name = "er-aws-rds"
-version = "0.6.6"
+version = "0.6.7"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
* `apply_method` change only will cause reconcile loop, detect it early on both create and update to prevent the loop described in https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group#problematic-plan-changes
* `apply_method` can't be `immediate` on `static` parameters such as `rds.logical_replication`, use this generic validation to cover old hard coded check.
* use boto3 paginator in aws api methods to avoid partial paginated response

[APPSRE-11695](https://issues.redhat.com/browse/APPSRE-11695)


### Parameter Validation and Error Handling:
* Removed the `RDSLogicalReplicationError` custom exception and the corresponding validation logic in `er_aws_rds/input.py`. [[1]](diffhunk://#diff-2ebfa68843ed03c75bcb199cb18ebadd895d7801ba50764b7081ae0c37995af1L1-L2) [[2]](diffhunk://#diff-fa4b05ce58b400425e2e210a5d5965854fe8c2eeb2490152b8e3774a25f1e7e8L267-L280)
* Added new methods for validating parameter group changes in `hooks/post_plan.py`, including `_validate_parameter_group_change`, `_validate_apply_method_change_only`, and `_validate_apply_method_with_apply_type`.

### Testing Enhancements:
* Updated tests in `tests/test_aws_api.py` to use parameterized testing for `get_db_parameters` and `get_engine_default_parameters` methods.
* Removed tests related to the deleted `RDSLogicalReplicationError` in `tests/test_input_validation.py`.
* Added mock AWS API responses in `tests/test_plan_validation.py` for better test coverage and accuracy.

### Version and Metadata Updates:
* Updated the version label in `Dockerfile` and `pyproject.toml` from `0.6.6` to `0.6.7`. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L3-R3) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3)