### PR TITLE
Parameter group validation on creation

### DIFF
--- a/hooks/post_plan.py
+++ b/hooks/post_plan.py
@@ -204,6 +204,15 @@ class RDSPlanValidator:
         if not change.after:
             return
 
+        parameter_group_name = change.after["name"]
+        if (
+            Action.ActionCreate in change.actions
+            and self.aws_api.get_db_parameter_group(parameter_group_name)
+        ):
+            self.errors.append(
+                f"Parameter group {parameter_group_name} already exists, use a different name"
+            )
+
         after_parameter_by_name = {
             parameter["name"]: Parameter.model_validate(parameter)
             for parameter in change.after.get("parameter") or []


### PR DESCRIPTION
As `old_parameter_group` deprecated, we need more strict validation on parameter group creation, to ensure new parameter group not exists yet, and use `create` in `actions` to determine creation instead of relying on empty `before` to cover replace case (`delete, create`).

[APPSRE-11657](https://issues.redhat.com/browse/APPSRE-11657)