### PR TITLE
Parameter group deletion validation

### DIFF
--- a/hooks/post_plan.py
+++ b/hooks/post_plan.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import logging
 import sys
+from collections.abc import Iterable, Iterator
 
 from external_resources_io.input import parse_model, read_input_from_file
 from external_resources_io.terraform import (
@@ -46,41 +47,69 @@ class RDSPlanValidator:
             if Action.ActionCreate in c.actions
         ]
 
+    @staticmethod
+    def _filter_by_actions(
+        resource_changes: Iterable[ResourceChange],
+        actions: set[Action],
+    ) -> Iterator[ResourceChange]:
+        return (
+            c
+            for c in resource_changes
+            if c.change and actions.intersection(c.change.actions)
+        )
+
+    @staticmethod
+    def _filter_by_type(
+        resource_changes: Iterable[ResourceChange],
+        resource_type: str,
+    ) -> Iterator[ResourceChange]:
+        return (c for c in resource_changes if c.type == resource_type)
+
     @property
     def resource_updates(self) -> list[ResourceChange]:
-        return [
-            c
-            for c in self.plan.resource_changes
-            if c.change and Action.ActionUpdate in c.change.actions
-        ]
+        return list(
+            self._filter_by_actions(self.plan.resource_changes, {Action.ActionUpdate})
+        )
 
     @property
     def resource_deletions(self) -> list[ResourceChange]:
-        return [
-            c
-            for c in self.plan.resource_changes
-            if c.change and Action.ActionDelete in c.change.actions
-        ]
+        return list(
+            self._filter_by_actions(self.plan.resource_changes, {Action.ActionDelete})
+        )
 
     @property
     def resource_creations(self) -> list[ResourceChange]:
-        return [
-            c
-            for c in self.plan.resource_changes
-            if c.change and Action.ActionCreate in c.change.actions
-        ]
+        return list(
+            self._filter_by_actions(self.plan.resource_changes, {Action.ActionCreate})
+        )
+
+    @property
+    def aws_db_instances(self) -> Iterator[ResourceChange]:
+        return self._filter_by_type(self.plan.resource_changes, "aws_db_instance")
 
     @property
     def aws_db_instance_creations(self) -> list[ResourceChange]:
-        return [c for c in self.resource_creations if c.type == "aws_db_instance"]
+        return list(
+            self._filter_by_actions(self.aws_db_instances, {Action.ActionCreate})
+        )
 
     @property
     def aws_db_instance_updates(self) -> list[ResourceChange]:
-        return [c for c in self.resource_updates if c.type == "aws_db_instance"]
+        return list(
+            self._filter_by_actions(self.aws_db_instances, {Action.ActionUpdate})
+        )
 
     @property
     def aws_db_instance_deletions(self) -> list[ResourceChange]:
-        return [c for c in self.resource_deletions if c.type == "aws_db_instance"]
+        return list(
+            self._filter_by_actions(self.aws_db_instances, {Action.ActionDelete})
+        )
+
+    @property
+    def aws_db_parameter_groups(self) -> Iterator[ResourceChange]:
+        return self._filter_by_type(
+            self.plan.resource_changes, "aws_db_parameter_group"
+        )
 
     def _validate_version_on_create(self) -> None:
         """Validates the RDS instance desired version (new instance)"""
@@ -152,11 +181,9 @@ class RDSPlanValidator:
             Action.ActionCreate,
             Action.ActionUpdate,
         }
-        resource_changes = [
-            c
-            for c in self.plan.resource_changes
-            if c.change and changed_actions.intersection(c.change.actions)
-        ]
+        resource_changes = list(
+            self._filter_by_actions(self.plan.resource_changes, changed_actions)
+        )
         if resource_changes:
             self.errors.append(
                 f"No changes allowed when Blue/Green Deployment enabled, detected changes: {resource_changes}"
@@ -262,25 +289,21 @@ class RDSPlanValidator:
             Action.ActionCreate,
             Action.ActionUpdate,
         }
-        for c in self.plan.resource_changes:
-            if (
-                c.change
-                and changed_actions.intersection(c.change.actions)
-                and c.type == "aws_db_parameter_group"
-            ):
+        for c in self._filter_by_actions(self.aws_db_parameter_groups, changed_actions):
+            if c.change:
                 self._validate_parameter_group_change(c.change)
 
     def _validate_parameter_group_deletion(self) -> None:
         delete_parameter_group_names = {
             name
-            for c in self.resource_deletions
-            if c.type == "aws_db_parameter_group"
-            and c.change
-            and c.change.before
-            and (name := c.change.before.get("name"))
+            for c in self._filter_by_actions(
+                self.aws_db_parameter_groups,
+                {Action.ActionDelete},
+            )
+            if c.change and c.change.before and (name := c.change.before.get("name"))
         }
         aws_db_instance = next(
-            (c for c in self.plan.resource_changes if c.type == "aws_db_instance"),
+            self.aws_db_instances,
             None,
         )
         if (


### PR DESCRIPTION
Throw error when unset `parameter_group` since terraform will ignore it, and it will fail during parameter group deletion as RDS instance is still using it.

[APPSRE-11722](https://issues.redhat.com/browse/APPSRE-11722)

### Code Refactoring:

* Added `_filter_by_actions` and `_filter_by_type` static methods to filter resource changes by actions and type, respectively. These methods improve code reuse and readability.
* Updated existing property methods (`resource_updates`, `resource_deletions`, `resource_creations`, `aws_db_instance_creations`, `aws_db_instance_updates`, `aws_db_instance_deletions`) to use the new filtering utility methods.
* Added new properties `aws_db_instances` and `aws_db_parameter_groups` to filter resource changes by specific AWS resource types.

### Validation Enhancements:

* Introduced `_validate_parameter_group_deletion` method to ensure parameter groups are not deleted incorrectly, especially in the context of blue/green deployments.
* Updated the `validate` method to include the new `_validate_parameter_group_deletion` check.

### Testing:

* Added a new test `test_validate_parameter_group_deletion` to verify the new validation logic for parameter group deletions.