### PR TITLE
feat: validate cross-region read replicas for blue_green_deployment

### DIFF
--- a/er_aws_rds/input.py
+++ b/er_aws_rds/input.py
@@ -344,6 +344,10 @@ class Rds(RdsAppInterface):
                 raise ValueError(
                     "deletion_protection must be disabled when replica_source has blue_green_deployment enabled"
                 )
+            if self.region != self.replica_source.region:
+                raise ValueError(
+                    "Cross-region read replicas are not currently supported for Blue Green Deployments"
+                )
         if self.is_read_replica and self.blue_green_deployment:
             raise ValueError(
                 "blue_green_deployment is not supported for replica instance"

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -295,6 +295,27 @@ def test_validate_blue_green_deployment_for_replica() -> None:
         AppInterfaceInput.model_validate(mod_input)
 
 
+def test_validate_blue_green_deployment_for_cross_region_replica() -> None:
+    """Test that cross-region read replicas are not supported for blue green deployments"""
+    mod_input = input_data({
+        "data": {
+            "replica_source": {
+                "identifier": "test-rds-source",
+                "region": "us-east-1",
+                "blue_green_deployment_enabled": True,
+            },
+            "region": "us-west-2",
+            "db_subnet_group_name": "test-subnet-group",
+            "parameter_group": None,
+        }
+    })
+    with pytest.raises(
+        ValidationError,
+        match=r".*Cross-region read replicas are not currently supported for Blue Green Deployments*",
+    ):
+        AppInterfaceInput.model_validate(mod_input)
+
+
 def test_validate_blue_green_deployment_when_desired_config_not_match_target_after_delete() -> (
     None
 ):


### PR DESCRIPTION
Validate cross region read replicas according to https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/blue-green-deployments-considerations.html

> Cross-region read replicas are not currently supported for Blue Green Deployments

[APPSRE-11707](https://issues.redhat.com/browse/APPSRE-11707)

Validation logic improvements:

* [`er_aws_rds/input.py`](diffhunk://#diff-fa4b05ce58b400425e2e210a5d5965854fe8c2eeb2490152b8e3774a25f1e7e8R347-R350): Added a check to ensure that cross-region read replicas are not supported for blue-green deployments and raise a `ValueError` if this condition is met.

Testing enhancements:

* [`tests/test_input_validation.py`](diffhunk://#diff-08fc3d02ead45670ed98689a721d71d5e8135f5bdf27a1bc64f3800944694c81R298-R318): Added a new test case `test_validate_blue_green_deployment_for_cross_region_replica` to verify that the validation logic correctly raises an error when cross-region read replicas are used with blue-green deployments.