### PR TITLE
Validate read replica has matching desired config as replica source instance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/redhat-services-prod/app-sre-tenant/er-base-terraform-main/er-base-terraform-main:tf-1.6.6-py-3.12-v0.3.4-1@sha256:1579e58702182a02b55a0841254d188a6b99ff42c774279890567338c863a31b AS base
 # keep in sync with pyproject.toml
-LABEL konflux.additional-tags="0.6.7"
+LABEL konflux.additional-tags="0.6.8"
 
 FROM base AS builder
 COPY --from=ghcr.io/astral-sh/uv:0.6.12@sha256:515b886e8eb99bcf9278776d8ea41eb4553a794195ef5803aa7ca6258653100d /uv /bin/uv

--- a/er_aws_rds/input.py
+++ b/er_aws_rds/input.py
@@ -335,10 +335,24 @@ class Rds(RdsAppInterface):
 
     @model_validator(mode="after")
     def _validate_blue_green_deployment_for_replica(self) -> Self:
+        """
+        Validate the blue_green_deployment for read replicas
+
+        * blue_green_deployment is not supported for read replica instance (only supported for primary instance)
+        * If the replica_source has blue_green_deployment enabled
+          * parameter_group must be None
+          * deletion_protection must be False
+          * region must match replica_source region
+          * engine_version must match replica_source engine_version if specified in target after switchover and delete,
+            note only engine_version is applied to all instances,
+            instance-class is supposed to be applied to all instances but actually only applied to primary instance,
+            so we only validate engine_version.
+            doc: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/blue-green-deployments-creating.html#create-blue-green-settings
+        """
         if (
             self.replica_source
-            and self.replica_source.blue_green_deployment
-            and self.replica_source.blue_green_deployment.enabled
+            and (blue_green_deployment := self.replica_source.blue_green_deployment)
+            and blue_green_deployment.enabled
         ):
             if self.parameter_group:
                 raise ValueError(
@@ -351,6 +365,16 @@ class Rds(RdsAppInterface):
             if self.region != self.replica_source.region:
                 raise ValueError(
                     "Cross-region read replicas are not currently supported for Blue Green Deployments"
+                )
+            if (
+                blue_green_deployment.switchover
+                and blue_green_deployment.delete
+                and blue_green_deployment.target
+                and (engine_version := blue_green_deployment.target.engine_version)
+                and engine_version != self.engine_version
+            ):
+                raise ValueError(
+                    f"desired config not match replica_source blue_green_deployment.target, update engine_version: {engine_version}"
                 )
         if self.is_read_replica and self.blue_green_deployment:
             raise ValueError(

--- a/er_aws_rds/input.py
+++ b/er_aws_rds/input.py
@@ -65,14 +65,6 @@ class ParameterGroup(BaseModel):
     parameters: list[Parameter] | None = Field(default=None)
 
 
-class ReplicaSource(BaseModel):
-    "AppInterface ReplicaSource"
-
-    region: str
-    identifier: str
-    blue_green_deployment_enabled: bool
-
-
 class BlueGreenDeploymentTarget(BaseModel):
     "AppInterface BlueGreenDeployment.Target"
 
@@ -93,6 +85,14 @@ class BlueGreenDeployment(BaseModel):
     delete: bool | None = None
     switchover_timeout: int | None = None
     target: BlueGreenDeploymentTarget | None = None
+
+
+class ReplicaSource(BaseModel):
+    "AppInterface ReplicaSource"
+
+    region: str
+    identifier: str
+    blue_green_deployment: BlueGreenDeployment | None = None
 
 
 class DBInstanceTimeouts(BaseModel):
@@ -335,7 +335,11 @@ class Rds(RdsAppInterface):
 
     @model_validator(mode="after")
     def _validate_blue_green_deployment_for_replica(self) -> Self:
-        if self.replica_source and self.replica_source.blue_green_deployment_enabled:
+        if (
+            self.replica_source
+            and self.replica_source.blue_green_deployment
+            and self.replica_source.blue_green_deployment.enabled
+        ):
             if self.parameter_group:
                 raise ValueError(
                     "parameter_group is not supported when replica_source has blue_green_deployment enabled"

--- a/er_aws_rds/input.py
+++ b/er_aws_rds/input.py
@@ -373,8 +373,11 @@ class Rds(RdsAppInterface):
                 and (engine_version := blue_green_deployment.target.engine_version)
                 and engine_version != self.engine_version
             ):
+                not_matched = {
+                    "engine_version": engine_version,
+                }
                 raise ValueError(
-                    f"desired config not match replica_source blue_green_deployment.target, update engine_version: {engine_version}"
+                    f"desired config not match replica_source blue_green_deployment.target, update: {not_matched}"
                 )
         if self.is_read_replica and self.blue_green_deployment:
             raise ValueError(

--- a/hooks/utils/blue_green_deployment_manager.py
+++ b/hooks/utils/blue_green_deployment_manager.py
@@ -54,8 +54,10 @@ class BlueGreenDeploymentManager:
     def run(self) -> State:
         """Run Blue/Green Deployment Manager"""
         if (
-            replica_source := self.app_interface_input.data.replica_source
-        ) and replica_source.blue_green_deployment_enabled:
+            (replica_source := self.app_interface_input.data.replica_source)
+            and replica_source.blue_green_deployment
+            and replica_source.blue_green_deployment.enabled
+        ):
             self.logger.info("blue_green_deployment in replica_source enabled.")
             return State.REPLICA_SOURCE_ENABLED
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-aws-rds"
-version = "0.6.7"
+version = "0.6.8"
 description = "ERv2 module for managing AWS rds instances"
 authors = [{ name = "AppSRE", email = "sd-app-sre@redhat.com" }]
 license = { text = "Apache 2.0" }

--- a/tests/test_blue_green_deployment_manager.py
+++ b/tests/test_blue_green_deployment_manager.py
@@ -1121,7 +1121,9 @@ def test_run_for_read_replica_has_blue_green_deployment_enabled(
             "replica_source": {
                 "identifier": "test-rds-source",
                 "region": "us-east-1",
-                "blue_green_deployment_enabled": True,
+                "blue_green_deployment": {
+                    "enabled": True,
+                },
             },
             "parameter_group": None,
         }

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -240,7 +240,9 @@ def test_validate_blue_green_deployment_for_replica_with_parameter_group() -> No
             "replica_source": {
                 "identifier": "test-rds-source",
                 "region": "us-east-1",
-                "blue_green_deployment_enabled": True,
+                "blue_green_deployment": {
+                    "enabled": True,
+                },
             },
             "parameter_group": DEFAULT_PARAMETER_GROUP,
         }
@@ -259,7 +261,9 @@ def test_validate_blue_green_deployment_for_replica_with_deletion_protection() -
             "replica_source": {
                 "identifier": "test-rds-source",
                 "region": "us-east-1",
-                "blue_green_deployment_enabled": True,
+                "blue_green_deployment": {
+                    "enabled": True,
+                },
             },
             "parameter_group": None,
             "deletion_protection": True,
@@ -279,7 +283,9 @@ def test_validate_blue_green_deployment_for_replica() -> None:
             "replica_source": {
                 "identifier": "test-rds-source",
                 "region": "us-east-1",
-                "blue_green_deployment_enabled": False,
+                "blue_green_deployment": {
+                    "enabled": False,
+                },
             },
             "blue_green_deployment": {
                 "enabled": False,
@@ -302,7 +308,9 @@ def test_validate_blue_green_deployment_for_cross_region_replica() -> None:
             "replica_source": {
                 "identifier": "test-rds-source",
                 "region": "us-east-1",
-                "blue_green_deployment_enabled": True,
+                "blue_green_deployment": {
+                    "enabled": True,
+                },
             },
             "region": "us-west-2",
             "db_subnet_group_name": "test-subnet-group",

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -276,6 +276,32 @@ def test_validate_blue_green_deployment_for_replica_with_deletion_protection() -
         AppInterfaceInput.model_validate(mod_input)
 
 
+def test_validate_blue_green_deployment_for_replica_when_desired_config_not_match_target() -> (
+    None
+):
+    """Test replica desired config match target"""
+    mod_input = input_data({
+        "data": {
+            "replica_source": {
+                "identifier": "test-rds-source",
+                "region": "us-east-1",
+                "blue_green_deployment": {
+                    "enabled": True,
+                    "switchover": True,
+                    "delete": True,
+                    "target": DEFAULT_TARGET,
+                },
+            },
+            "parameter_group": None,
+        }
+    })
+    with pytest.raises(
+        ValidationError,
+        match=r".*desired config not match replica_source blue_green_deployment.target, update engine_version: 15.7.*",
+    ):
+        AppInterfaceInput.model_validate(mod_input)
+
+
 def test_validate_blue_green_deployment_for_replica() -> None:
     """Test that blue_green_deployment is not supported for replica instance"""
     mod_input = input_data({

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -295,9 +295,12 @@ def test_validate_blue_green_deployment_for_replica_when_desired_config_not_matc
             "parameter_group": None,
         }
     })
+    expected_not_matched = {
+        "engine_version": "15.7",
+    }
     with pytest.raises(
         ValidationError,
-        match=r".*desired config not match replica_source blue_green_deployment.target, update engine_version: 15.7.*",
+        match=rf".*desired config not match replica_source blue_green_deployment.target, update: {expected_not_matched}.*",
     ):
         AppInterfaceInput.model_validate(mod_input)
 
@@ -366,6 +369,6 @@ def test_validate_blue_green_deployment_when_desired_config_not_match_target_aft
     })
     with pytest.raises(
         ValidationError,
-        match=r".*desired config not match blue_green_deployment.target after delete.*",
+        match=r".*desired config not match blue_green_deployment.target after delete, update: .*",
     ):
         AppInterfaceInput.model_validate(mod_input)

--- a/uv.lock
+++ b/uv.lock
@@ -99,7 +99,7 @@ wheels = [
 
 [[package]]
 name = "er-aws-rds"
-version = "0.6.7"
+version = "0.6.8"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Validate read replica config (`engine_version`) is matching replica source instance after blue/green deployment done, so terraform can just refresh to sync state.

[APPSRE-11714](https://issues.redhat.com/browse/APPSRE-11714)

### Enhancements to blue-green deployment:

* [`er_aws_rds/input.py`](diffhunk://#diff-fa4b05ce58b400425e2e210a5d5965854fe8c2eeb2490152b8e3774a25f1e7e8L68-L75): Restructured the `ReplicaSource` class to include a `blue_green_deployment` attribute instead of `blue_green_deployment_enabled`, and added validation logic to ensure configurations match the requirements for blue-green deployments. [[1]](diffhunk://#diff-fa4b05ce58b400425e2e210a5d5965854fe8c2eeb2490152b8e3774a25f1e7e8L68-L75) [[2]](diffhunk://#diff-fa4b05ce58b400425e2e210a5d5965854fe8c2eeb2490152b8e3774a25f1e7e8R90-R97) [[3]](diffhunk://#diff-fa4b05ce58b400425e2e210a5d5965854fe8c2eeb2490152b8e3774a25f1e7e8L338-R356) [[4]](diffhunk://#diff-fa4b05ce58b400425e2e210a5d5965854fe8c2eeb2490152b8e3774a25f1e7e8R369-R378)
* [`hooks/utils/blue_green_deployment_manager.py`](diffhunk://#diff-afae0537961d67b038f5da0fff66bfa992b336aa0d8179faaecfc174cb1b9197L57-R60): Updated the `run` method to check for the new `blue_green_deployment` attribute.

### Test case updates:

* [`tests/test_blue_green_deployment_manager.py`](diffhunk://#diff-987ea879ee84472c65e56cdf5131d1e8183860f12a48f98391cf52177b70ba28L1124-R1126): Modified test cases to use the new `blue_green_deployment` attribute.
* [`tests/test_input_validation.py`](diffhunk://#diff-08fc3d02ead45670ed98689a721d71d5e8135f5bdf27a1bc64f3800944694c81L243-R245): Updated existing test cases and added new ones to validate the blue-green deployment configurations. [[1]](diffhunk://#diff-08fc3d02ead45670ed98689a721d71d5e8135f5bdf27a1bc64f3800944694c81L243-R245) [[2]](diffhunk://#diff-08fc3d02ead45670ed98689a721d71d5e8135f5bdf27a1bc64f3800944694c81L262-R266) [[3]](diffhunk://#diff-08fc3d02ead45670ed98689a721d71d5e8135f5bdf27a1bc64f3800944694c81R279-R314) [[4]](diffhunk://#diff-08fc3d02ead45670ed98689a721d71d5e8135f5bdf27a1bc64f3800944694c81L305-R339)

### Version updates:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L3-R3): Updated the `konflux.additional-tags` label to `0.6.8`.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Bumped the project version to `0.6.8`.