### PR TITLE
fix: handle parameter group not found error

### DIFF
--- a/hooks/utils/aws_api.py
+++ b/hooks/utils/aws_api.py
@@ -94,7 +94,12 @@ class AWSApi:
 
     def get_db_parameter_group(self, name: str) -> DBParameterGroupTypeDef | None:
         """Get DB parameter group info"""
-        data = self.rds_client.describe_db_parameter_groups(DBParameterGroupName=name)
+        try:
+            data = self.rds_client.describe_db_parameter_groups(
+                DBParameterGroupName=name
+            )
+        except self.rds_client.exceptions.DBParameterGroupNotFoundFault:
+            return None
         return data["DBParameterGroups"][0] if data["DBParameterGroups"] else None
 
     def get_db_parameters(

--- a/tests/test_aws_api.py
+++ b/tests/test_aws_api.py
@@ -332,6 +332,15 @@ def test_get_db_parameter_group_when_not_found(mock_rds_client: Mock) -> None:
     mock_rds_client.describe_db_parameter_groups.return_value = {
         "DBParameterGroups": []
     }
+    mock_rds_client.exceptions.DBParameterGroupNotFoundFault = ClientError
+    mock_rds_client.describe_db_parameter_groups.side_effect = ClientError(
+        error_response={
+            "Error": {
+                "Code": "DBParameterGroupNotFound",
+            },
+        },
+        operation_name="DescribeDBParameterGroups",
+    )
 
     result = aws_api.get_db_parameter_group("name")
 


### PR DESCRIPTION
Fix parameter group check introduced in https://github.com/app-sre/er-aws-rds/pull/135

`rds_client.describe_db_parameter_groups` will throw exception instead of return empty list.

[APPSRE-11722](https://issues.redhat.com/browse/APPSRE-11722)