### PR TITLE
feat: support pending prepares to be applied in blue/green deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 AWS_SHARED_CREDENTIALS_FILE=credentials
 INPUT_FILE=input.json
 PLAN_FILE_JSON=module/plan.json
+WORK=tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/redhat-services-prod/app-sre-tenant/er-base-terraform-main/er-base-terraform-main:tf-1.6.6-py-3.12-v0.3.4-1@sha256:1579e58702182a02b55a0841254d188a6b99ff42c774279890567338c863a31b AS base
 # keep in sync with pyproject.toml
-LABEL konflux.additional-tags="0.6.8"
+LABEL konflux.additional-tags="0.6.9"
 
 FROM base AS builder
 COPY --from=ghcr.io/astral-sh/uv:0.6.14@sha256:3362a526af7eca2fcd8604e6a07e873fb6e4286d8837cb753503558ce1213664 /uv /bin/uv

--- a/hooks/post_plan.py
+++ b/hooks/post_plan.py
@@ -175,6 +175,7 @@ class RDSPlanValidator:
         if (
             self.input.data.blue_green_deployment is None
             or not self.input.data.blue_green_deployment.enabled
+            or not self.input.data.blue_green_deployment.delete
         ):
             return
         changed_actions = {
@@ -186,7 +187,7 @@ class RDSPlanValidator:
         )
         if resource_changes:
             self.errors.append(
-                f"No changes allowed when Blue/Green Deployment enabled, detected changes: {resource_changes}"
+                f"No changes allowed when sync after Blue/Green Deployment completed, detected changes: {resource_changes}"
             )
 
     @staticmethod

--- a/hooks/post_plan.py
+++ b/hooks/post_plan.py
@@ -187,7 +187,7 @@ class RDSPlanValidator:
         )
         if resource_changes:
             self.errors.append(
-                f"There are pending resource changes after a Blue/Green Deployment.  This should not happen. Detected changes: {resource_changes}"
+                f"There are pending resource changes after a Blue/Green Deployment. This should not happen. Detected changes: {resource_changes}"
             )
 
     @staticmethod

--- a/hooks/post_plan.py
+++ b/hooks/post_plan.py
@@ -187,7 +187,7 @@ class RDSPlanValidator:
         )
         if resource_changes:
             self.errors.append(
-                f"No changes allowed when sync after Blue/Green Deployment completed, detected changes: {resource_changes}"
+                f"There are pending resource changes after a Blue/Green Deployment.  This should not happen. Detected changes: {resource_changes}"
             )
 
     @staticmethod

--- a/hooks/post_run.py
+++ b/hooks/post_run.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+import logging
+import sys
+
+from external_resources_io.exit_status import EXIT_ERROR, EXIT_OK
+
+from hooks.utils.logger import setup_logging
+from hooks.utils.runtime import should_rerun
+
+
+def main() -> None:
+    """Determine if required to rerun the job"""
+    setup_logging()
+    logger = logging.getLogger(__name__)
+    if should_rerun():
+        logger.info("rerun marker exists, exiting with error")
+        sys.exit(EXIT_ERROR)
+    else:
+        logger.info("run completed successfully")
+        sys.exit(EXIT_OK)
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/utils/blue_green_deployment_manager.py
+++ b/hooks/utils/blue_green_deployment_manager.py
@@ -74,6 +74,15 @@ class BlueGreenDeploymentManager:
                 self.model.state = action.next_state
             return self.model.state
 
+        if pending_prepares := self.model.pending_prepares:
+            self.logger.info(f"Pending prepares needed: {', '.join(pending_prepares)}")
+            if self.dry_run:
+                for action in actions:
+                    self.logger.info(
+                        f"Action {action.type}: {action.model_dump_json()}"
+                    )
+            return State.PENDING_PREPARE
+
         for action in actions:
             self.logger.info(f"Action {action.type}: {action.model_dump_json()}")
             if not self.dry_run:

--- a/hooks/utils/blue_green_deployment_model.py
+++ b/hooks/utils/blue_green_deployment_model.py
@@ -114,7 +114,10 @@ class BlueGreenDeploymentModel(BaseModel):
     @model_validator(mode="after")
     def _validate_backup_retention_period(self) -> Self:
         if self.db_instance and self.db_instance["BackupRetentionPeriod"] <= 0:
-            raise ValueError("backup_retention_period must be greater than 0")
+            if self.input_data.backup_retention_period:
+                self._pending_prepares.append(PendingPrepare.BACKUP_RETENTION_PERIOD)
+            else:
+                raise ValueError("backup_retention_period must be greater than 0")
         return self
 
     @model_validator(mode="after")

--- a/hooks/utils/blue_green_deployment_model.py
+++ b/hooks/utils/blue_green_deployment_model.py
@@ -114,7 +114,10 @@ class BlueGreenDeploymentModel(BaseModel):
     @model_validator(mode="after")
     def _validate_backup_retention_period(self) -> Self:
         if self.db_instance and self.db_instance["BackupRetentionPeriod"] <= 0:
-            if self.input_data.backup_retention_period:
+            if (
+                self.input_data.backup_retention_period
+                and self.input_data.backup_retention_period > 0
+            ):
                 self._pending_prepares.add(PendingPrepare.BACKUP_RETENTION_PERIOD)
             else:
                 raise ValueError("backup_retention_period must be greater than 0")

--- a/hooks/utils/blue_green_deployment_model.py
+++ b/hooks/utils/blue_green_deployment_model.py
@@ -105,10 +105,9 @@ class BlueGreenDeploymentModel(BaseModel):
     @model_validator(mode="after")
     def _validate_deletion_protection(self) -> Self:
         if self.db_instance and self.db_instance["DeletionProtection"]:
-            if not self.input_data.deletion_protection:
-                self._pending_prepares.add(PendingPrepare.DELETION_PROTECTION)
-            else:
+            if self.input_data.deletion_protection:
                 raise ValueError("deletion_protection must be disabled")
+            self._pending_prepares.add(PendingPrepare.DELETION_PROTECTION)
         return self
 
     @model_validator(mode="after")

--- a/hooks/utils/blue_green_deployment_model.py
+++ b/hooks/utils/blue_green_deployment_model.py
@@ -105,7 +105,10 @@ class BlueGreenDeploymentModel(BaseModel):
     @model_validator(mode="after")
     def _validate_deletion_protection(self) -> Self:
         if self.db_instance and self.db_instance["DeletionProtection"]:
-            raise ValueError("deletion_protection must be disabled")
+            if not self.input_data.deletion_protection:
+                self._pending_prepares.append(PendingPrepare.DELETION_PROTECTION)
+            else:
+                raise ValueError("deletion_protection must be disabled")
         return self
 
     @model_validator(mode="after")

--- a/hooks/utils/models.py
+++ b/hooks/utils/models.py
@@ -56,6 +56,7 @@ class State(StrEnum):
     SOURCE_DB_INSTANCES_DELETED = "source_db_instances_deleted"
     DELETING = "deleting"
     NO_OP = "no_op"
+    PENDING_PREPARE = "pending_prepare"
 
 
 class ActionType(StrEnum):

--- a/hooks/utils/models.py
+++ b/hooks/utils/models.py
@@ -59,6 +59,14 @@ class State(StrEnum):
     PENDING_PREPARE = "pending_prepare"
 
 
+class PendingPrepare(StrEnum):
+    """Pending Prepare Enum"""
+
+    TARGET_PARAMETER_GROUP = "target_parameter_group"
+    DELETION_PROTECTION = "deletion_protection"
+    BACKUP_RETENTION_PERIOD = "backup_retention_period"
+
+
 class ActionType(StrEnum):
     """Action Enum"""
 

--- a/hooks/utils/runtime.py
+++ b/hooks/utils/runtime.py
@@ -1,6 +1,24 @@
 import os
+from pathlib import Path
 
 
 def is_dry_run() -> bool:
     """Checks if the run is a DRY_RUN"""
     return os.getenv("DRY_RUN", "True") == "True"
+
+
+def _get_rerun_marker_path() -> Path:
+    workdir = os.getenv("WORK")
+    if not workdir:
+        raise ValueError("WORK environment variable is not set")
+    return Path(workdir) / "rerun"
+
+
+def mark_rerun() -> None:
+    """Mark the current run requires a rerun by creating a marker file."""
+    _get_rerun_marker_path().touch(exist_ok=True)
+
+
+def should_rerun() -> bool:
+    """Check if the current run requires a rerun by checking the marker file."""
+    return _get_rerun_marker_path().exists()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-aws-rds"
-version = "0.6.8"
+version = "0.6.9"
 description = "ERv2 module for managing AWS rds instances"
 authors = [{ name = "AppSRE", email = "sd-app-sre@redhat.com" }]
 license = { text = "Apache 2.0" }

--- a/tests/test_blue_green_deployment_model.py
+++ b/tests/test_blue_green_deployment_model.py
@@ -65,7 +65,7 @@ def test_validate_target_parameter_group() -> None:
         valid_upgrade_targets=DEFAULT_VALID_UPGRADE_TARGETS,
     )
 
-    assert model.pending_prepares == [PendingPrepare.TARGET_PARAMETER_GROUP]
+    assert model.pending_prepares == {PendingPrepare.TARGET_PARAMETER_GROUP}
 
 
 def test_validate_deletion_protection() -> None:
@@ -96,7 +96,7 @@ def test_validate_deletion_protection_requires_pending_prepare(
         valid_upgrade_targets=DEFAULT_VALID_UPGRADE_TARGETS,
     )
 
-    assert model.pending_prepares == [PendingPrepare.DELETION_PROTECTION]
+    assert model.pending_prepares == {PendingPrepare.DELETION_PROTECTION}
 
 
 @pytest.mark.parametrize("backup_retention_period", [0, None])
@@ -124,7 +124,7 @@ def test_validate_backup_retention_period_with_pending_prepares() -> None:
         valid_upgrade_targets=DEFAULT_VALID_UPGRADE_TARGETS,
     )
 
-    assert model.pending_prepares == [PendingPrepare.BACKUP_RETENTION_PERIOD]
+    assert model.pending_prepares == {PendingPrepare.BACKUP_RETENTION_PERIOD}
 
 
 def test_validate_version_upgrade_when_target_set() -> None:

--- a/tests/test_blue_green_deployment_model.py
+++ b/tests/test_blue_green_deployment_model.py
@@ -8,7 +8,7 @@ from er_aws_rds.input import (
     ParameterGroup,
 )
 from hooks.utils.blue_green_deployment_model import BlueGreenDeploymentModel
-from hooks.utils.models import State
+from hooks.utils.models import PendingPrepare, State
 from tests.conftest import (
     DEFAULT_RDS_INSTANCE,
     DEFAULT_SOURCE_DB_PARAMETERS,
@@ -44,20 +44,20 @@ def test_validate_db_instance_exist() -> None:
 
 def test_validate_target_parameter_group() -> None:
     """Test validate target parameter group"""
-    with pytest.raises(
-        ValidationError, match=r".*Target Parameter Group not found: pg15.*"
-    ):
-        BlueGreenDeploymentModel(
-            db_instance_identifier="test-rds",
-            state=State.INIT,
-            config=build_blue_green_deployment(
-                target=BlueGreenDeploymentTarget(
-                    parameter_group=ParameterGroup(family="postgres15", name="pg15")
-                )
-            ),
-            db_instance=DEFAULT_RDS_INSTANCE,
-            target_db_parameter_group=None,
-        )
+    model = BlueGreenDeploymentModel(
+        db_instance_identifier="test-rds",
+        state=State.INIT,
+        config=build_blue_green_deployment(
+            target=BlueGreenDeploymentTarget(
+                parameter_group=ParameterGroup(family="postgres15", name="pg15")
+            )
+        ),
+        db_instance=DEFAULT_RDS_INSTANCE,
+        target_db_parameter_group=None,
+        valid_upgrade_targets=DEFAULT_VALID_UPGRADE_TARGETS,
+    )
+
+    assert model.pending_prepares == [PendingPrepare.TARGET_PARAMETER_GROUP]
 
 
 def test_validate_deletion_protection() -> None:

--- a/tests/test_blue_green_deployment_model.py
+++ b/tests/test_blue_green_deployment_model.py
@@ -22,7 +22,7 @@ def build_blue_green_deployment_input_data(
     switchover: bool = False,
     delete: bool = False,
     target: BlueGreenDeploymentTarget | None = None,
-    deletion_protection: bool = False,
+    deletion_protection: bool | None = None,
     backup_retention_period: int | None = None,
 ) -> Rds:
     """Build Rds input object"""
@@ -81,11 +81,17 @@ def test_validate_deletion_protection() -> None:
         )
 
 
-def test_validate_deletion_protection_requires_pending_prepare() -> None:
+@pytest.mark.parametrize("deletion_protection", [False, None])
+def test_validate_deletion_protection_requires_pending_prepare(
+    *,
+    deletion_protection: bool | None,
+) -> None:
     """Test validate deletion protection requires pending prepare"""
     model = BlueGreenDeploymentModel(
         state=State.INIT,
-        input_data=build_blue_green_deployment_input_data(deletion_protection=False),
+        input_data=build_blue_green_deployment_input_data(
+            deletion_protection=deletion_protection
+        ),
         db_instance=DEFAULT_RDS_INSTANCE | {"DeletionProtection": True},
         valid_upgrade_targets=DEFAULT_VALID_UPGRADE_TARGETS,
     )

--- a/tests/test_plan_validation.py
+++ b/tests/test_plan_validation.py
@@ -218,7 +218,7 @@ def test_validate_no_changes_when_blue_green_deployment_enabled(
     errors = validator.validate()
 
     assert errors == [
-        f"No changes allowed when Blue/Green Deployment enabled, detected changes: {plan.resource_changes}"
+        f"No changes allowed when sync after Blue/Green Deployment completed, detected changes: {plan.resource_changes}"
     ]
 
 
@@ -267,6 +267,53 @@ def test_validate_no_changes_allow_delete_when_blue_green_deployment_enabled(
                     "enabled": True,
                     "switchover": True,
                     "delete": True,
+                }
+            }
+        }),
+    )
+
+    errors = validator.validate()
+
+    assert errors == []
+
+
+def test_validate_no_changes_allow_when_blue_green_deployment_enabled_but_not_delete() -> (
+    None
+):
+    """Test no changes when Blue/Green Deployment is enabled"""
+    plan = Plan.model_validate({
+        "resource_changes": [
+            {
+                "type": "aws_db_instance",
+                "change": {
+                    "actions": ["update"],
+                    "before": {
+                        "id": "some-id",
+                        "name": "test-rds",
+                        "engine": "postgres",
+                        "engine_version": "15.7",
+                        "deletion_protection": True,
+                    },
+                    "after": {
+                        "id": "test-rds-pg15",
+                        "name": "test-rds-pg15",
+                        "engine": "postgres",
+                        "engine_version": "15.7",
+                        "deletion_protection": False,
+                    },
+                    "after_unknown": {},
+                },
+            },
+        ]
+    })
+    validator = RDSPlanValidator(
+        plan,
+        input_object({
+            "data": {
+                "blue_green_deployment": {
+                    "enabled": True,
+                    "switchover": True,
+                    "delete": False,
                 }
             }
         }),

--- a/tests/test_plan_validation.py
+++ b/tests/test_plan_validation.py
@@ -218,7 +218,7 @@ def test_validate_no_changes_when_blue_green_deployment_enabled(
     errors = validator.validate()
 
     assert errors == [
-        f"No changes allowed when sync after Blue/Green Deployment completed, detected changes: {plan.resource_changes}"
+        f"There are pending resource changes after a Blue/Green Deployment. This should not happen. Detected changes: {plan.resource_changes}"
     ]
 
 

--- a/tests/test_post_run.py
+++ b/tests/test_post_run.py
@@ -1,0 +1,36 @@
+from collections.abc import Iterator
+from unittest.mock import Mock, patch
+
+import pytest
+
+from hooks.post_run import main
+
+
+@pytest.fixture
+def mock_should_rerun() -> Iterator[Mock]:
+    """Patch mark_rerun"""
+    with patch("hooks.post_run.should_rerun") as m:
+        yield m
+
+
+@pytest.mark.parametrize(
+    ("should_rerun", "expected_exit_code"),
+    [
+        (True, 1),
+        (False, 0),
+    ],
+)
+def test_post_run_hook_when_no_rerun_marker(
+    mock_should_rerun: Mock,
+    *,
+    should_rerun: bool,
+    expected_exit_code: int,
+) -> None:
+    """Test post_run_hook when no rerun marker"""
+    mock_should_rerun.return_value = should_rerun
+
+    with pytest.raises(SystemExit) as e:
+        main()
+
+    assert e.value.code == expected_exit_code
+    mock_should_rerun.assert_called_once_with()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import pytest
+
+from hooks.utils.runtime import mark_rerun, should_rerun
+
+
+def test_mark_rerun(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test mark_rerun"""
+    marker_path = tmp_path / "rerun"
+    monkeypatch.setenv("WORK", str(tmp_path))
+
+    mark_rerun()
+
+    assert marker_path.exists()
+
+
+def test_mark_rerun_with_missing_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test mark_rerun with missing WORK env"""
+    monkeypatch.delenv("WORK", raising=False)
+
+    with pytest.raises(ValueError, match="WORK environment variable is not set"):
+        mark_rerun()
+
+
+def test_should_rerun_when_marker_exist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test should_rerun when marker exists"""
+    marker_path = tmp_path / "rerun"
+    marker_path.touch()
+    monkeypatch.setenv("WORK", str(tmp_path))
+
+    result = should_rerun()
+
+    assert result is True
+
+
+def test_should_rerun_when_marker_does_not_exist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test should_rerun when marker does not exist"""
+    monkeypatch.setenv("WORK", str(tmp_path))
+
+    result = should_rerun()
+
+    assert result is False
+
+
+def test_should_rerun_with_missing_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test should_rerun with missing WORK env"""
+    monkeypatch.delenv("WORK", raising=False)
+
+    with pytest.raises(ValueError, match="WORK environment variable is not set"):
+        should_rerun()

--- a/uv.lock
+++ b/uv.lock
@@ -99,7 +99,7 @@ wheels = [
 
 [[package]]
 name = "er-aws-rds"
-version = "0.6.8"
+version = "0.6.9"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
[APPSRE-11434](https://issues.redhat.com/browse/APPSRE-11434)

When there are changes required for blue/green deployment, but can be done via terraform, pre_run hook will mark it as rerun, then post_run hook will exit as error to rerun after terraform flow.

Supported pending prepares are:

* deletion_protection
* backup_retention_period
* target parameter_group

This will allow prepare and create blue/green deployment in one change, note `delete` has to be `False` otherwise terraform will try to apply other changes should be done in blue/green deployment, post_plan validation will catch that.


### Enhancements to Blue/Green Deployment:

* [`hooks/post_plan.py`](diffhunk://#diff-e1e101fc08c044624f7b3896a524c3e118c82887f9fa2f4e88b6b3c2c58959d6R178): Added a condition to check for the `delete` attribute in Blue/Green Deployment and updated the error message to reflect synchronization after deployment completion. [[1]](diffhunk://#diff-e1e101fc08c044624f7b3896a524c3e118c82887f9fa2f4e88b6b3c2c58959d6R178) [[2]](diffhunk://#diff-e1e101fc08c044624f7b3896a524c3e118c82887f9fa2f4e88b6b3c2c58959d6L189-R190)
* [`hooks/utils/blue_green_deployment_manager.py`](diffhunk://#diff-afae0537961d67b038f5da0fff66bfa992b336aa0d8179faaecfc174cb1b9197R54-R93): Introduced a `blue_green_deployment_name` property and updated methods to use `input_data` for configuration. Added handling for pending prepares and adjusted the `_build_model` method to use `input_data`. [[1]](diffhunk://#diff-afae0537961d67b038f5da0fff66bfa992b336aa0d8179faaecfc174cb1b9197R54-R93) [[2]](diffhunk://#diff-afae0537961d67b038f5da0fff66bfa992b336aa0d8179faaecfc174cb1b9197L85-R104) [[3]](diffhunk://#diff-afae0537961d67b038f5da0fff66bfa992b336aa0d8179faaecfc174cb1b9197L107-L123) [[4]](diffhunk://#diff-afae0537961d67b038f5da0fff66bfa992b336aa0d8179faaecfc174cb1b9197L202-R218) [[5]](diffhunk://#diff-afae0537961d67b038f5da0fff66bfa992b336aa0d8179faaecfc174cb1b9197L230-R247) [[6]](diffhunk://#diff-afae0537961d67b038f5da0fff66bfa992b336aa0d8179faaecfc174cb1b9197L283-R298)
* [`hooks/utils/blue_green_deployment_model.py`](diffhunk://#diff-914c23200f171521aea182feae576bfdaed6c30f19b4b9be3fb759cdb8732982L38-R49): Added `pending_prepares` property and updated validation methods to handle pending prepares. Adjusted the model to use `input_data` instead of individual attributes. [[1]](diffhunk://#diff-914c23200f171521aea182feae576bfdaed6c30f19b4b9be3fb759cdb8732982L38-R49) [[2]](diffhunk://#diff-914c23200f171521aea182feae576bfdaed6c30f19b4b9be3fb759cdb8732982R83-R122) [[3]](diffhunk://#diff-914c23200f171521aea182feae576bfdaed6c30f19b4b9be3fb759cdb8732982R196-R200) [[4]](diffhunk://#diff-914c23200f171521aea182feae576bfdaed6c30f19b4b9be3fb759cdb8732982L380-R399) [[5]](diffhunk://#diff-914c23200f171521aea182feae576bfdaed6c30f19b4b9be3fb759cdb8732982L389-R408)

### Rerun Mechanism:

* [`hooks/pre_run.py`](diffhunk://#diff-cf709ac2096dbe6c98a19716b4cba5eaa840aa655cb38df6ece115609e822544L13-R13): Added `mark_rerun` functionality to mark runs that need to be rerun and updated the main function to handle the new rerun state. [[1]](diffhunk://#diff-cf709ac2096dbe6c98a19716b4cba5eaa840aa655cb38df6ece115609e822544L13-R13) [[2]](diffhunk://#diff-cf709ac2096dbe6c98a19716b4cba5eaa840aa655cb38df6ece115609e822544R22-R26) [[3]](diffhunk://#diff-cf709ac2096dbe6c98a19716b4cba5eaa840aa655cb38df6ece115609e822544R50-R54)
* [`hooks/post_run.py`](diffhunk://#diff-5180cac0f1a317b3936ee962506c4eda9b2a768e9a0d802c8e74e6cccdac451aR1-R24): Introduced a new script to determine if a job needs to be rerun based on the presence of a rerun marker.
* [`hooks/utils/runtime.py`](diffhunk://#diff-ad9472268b530d9850f253f9eef22c0d709e1d0c2af9d7d7663188302cdac869R2-R24): Added functions to mark and check for rerun requirements by creating and checking a marker file.

### Dockerfile and Version Updates:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L3-R3): Updated the `konflux.additional-tags` label to `0.6.9`.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Updated the project version to `0.6.9`.

### Miscellaneous:

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR4): Added a new `WORK` environment variable.
* [`tests/test_blue_green_deployment_manager.py`](diffhunk://#diff-987ea879ee84472c65e56cdf5131d1e8183860f12a48f98391cf52177b70ba28R489): Added a mock for logging in the test case for Blue/Green Deployment with a parameter group not found.