### PR TITLE
fix not_matched if apply_method has not been set

### DIFF
--- a/er_aws_rds/input.py
+++ b/er_aws_rds/input.py
@@ -402,7 +402,7 @@ class Rds(RdsAppInterface):
                 storage_throughput=self.storage_throughput,
                 storage_type=self.storage_type,
                 parameter_group=self.parameter_group,
-            ).model_dump()
+            ).model_dump(exclude_none=True)
             target = self.blue_green_deployment.target.model_dump(exclude_none=True)
             not_matched = {k: v for k, v in target.items() if desired_config[k] != v}
             if not_matched:


### PR DESCRIPTION
If apply_method is not set, it will be None in desired_config but absent from the target, which will cause a not_matched to appear in this case.