### PR TITLE
Use tags as provider default_tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/redhat-services-prod/app-sre-tenant/er-base-terraform-main/er-base-terraform-main:0.3.8-13@sha256:a991d0835739fbed914f6433b0ce281939a4b47e65e6bdd4d994a953e50a63f6 AS base
 # keep in sync with pyproject.toml
-LABEL konflux.additional-tags="0.7.0"
+LABEL konflux.additional-tags="0.8.0"
 
 FROM base AS builder
 COPY --from=ghcr.io/astral-sh/uv:0.8.17@sha256:e4644cb5bd56fdc2c5ea3ee0525d9d21eed1603bccd6a21f887a938be7e85be1 /uv /bin/uv

--- a/er_aws_rds/input.py
+++ b/er_aws_rds/input.py
@@ -1,4 +1,3 @@
-from collections.abc import Sequence
 from typing import Any, Literal, Self
 
 from external_resources_io.input import AppInterfaceProvision
@@ -139,8 +138,7 @@ class RdsAppInterface(BaseModel):
     output_resource_name: str | None = Field(default=None, exclude=True)
     # output_prefix is not necessary since now each resources has it own state.
     output_prefix: str = Field(exclude=True)
-    tags: dict[str, Any] | None = Field(default=None, exclude=True)
-    default_tags: Sequence[dict[str, Any]] | None = Field(default=None, exclude=True)
+    tags: dict[str, str] = Field(default_factory=dict, exclude=True)
 
 
 class Rds(RdsAppInterface):

--- a/module/providers.tf
+++ b/module/providers.tf
@@ -2,11 +2,17 @@ variable "region" {}
 
 provider "aws" {
   region = var.region
+  default_tags {
+    tags = var.tags
+  }
 }
 
 provider "aws" {
   region = try(var.replica_source.region, var.region)
   alias  = "replica_source_provider"
+  default_tags {
+    tags = var.tags
+  }
 }
 
 provider "random" {}

--- a/module/variables.tf
+++ b/module/variables.tf
@@ -11,5 +11,8 @@ variable "parameter_groups" { default = null }
 variable "ca_cert" { default = null }
 variable "output_resource_db_name" { default = null }
 
-variable "tags" {}
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
 variable "provision" {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-aws-rds"
-version = "0.7.0"
+version = "0.8.0"
 description = "ERv2 module for managing AWS rds instances"
 authors = [{ name = "AppSRE", email = "sd-app-sre@redhat.com" }]
 license = { text = "Apache 2.0" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,7 +80,6 @@ DEFAULT_DATA = {
             "managed_by_integration": "external_resources",
             "namespace": "external-resources-poc",
         },
-        "default_tags": [{"tags": {"app": "app-sre-infra"}}],
     },
     "provision": {
         "provision_provider": "aws",

--- a/uv.lock
+++ b/uv.lock
@@ -100,7 +100,7 @@ wheels = [
 
 [[package]]
 name = "er-aws-rds"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Config provider to use tags as default_tags, ensure all resources created contain same tags.

Depends on https://github.com/app-sre/qontract-reconcile/pull/5220

[APPSRE-12469](https://issues.redhat.com/browse/APPSRE-12469)