### PR TITLE
refactor: log ValidationError without stack trace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/redhat-services-prod/app-sre-tenant/er-base-terraform-main/er-base-terraform-main:0.3.8-13@sha256:a991d0835739fbed914f6433b0ce281939a4b47e65e6bdd4d994a953e50a63f6 AS base
 # keep in sync with pyproject.toml
-LABEL konflux.additional-tags="0.9.0"
+LABEL konflux.additional-tags="0.9.1"
 
 FROM base AS builder
 COPY --from=ghcr.io/astral-sh/uv:0.8.18@sha256:62022a082ce1358336b920e9b7746ac7c95b1b11473aa93ab5e4f01232d6712d /uv /bin/uv

--- a/hooks/pre_run.py
+++ b/hooks/pre_run.py
@@ -4,6 +4,7 @@ import sys
 
 from external_resources_io.exit_status import EXIT_ERROR, EXIT_OK, EXIT_SKIP
 from external_resources_io.input import parse_model, read_input_from_file
+from pydantic import ValidationError
 
 from er_aws_rds.input import AppInterfaceInput
 from hooks.utils.aws_api import AWSApi
@@ -27,6 +28,9 @@ def main() -> None:
     )
     try:
         state = manager.run()
+    except ValidationError as e:
+        logger.error("Validation Error for Blue/Green Deployment management: %s", e)  # noqa: TRY400
+        sys.exit(EXIT_ERROR)
     except Exception:
         logger.exception("Error during Blue/Green Deployment management")
         sys.exit(EXIT_ERROR)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-aws-rds"
-version = "0.9.0"
+version = "0.9.1"
 description = "ERv2 module for managing AWS rds instances"
 authors = [{ name = "AppSRE", email = "sd-app-sre@redhat.com" }]
 license = { text = "Apache 2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -102,7 +102,7 @@ wheels = [
 
 [[package]]
 name = "er-aws-rds"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
`ValidationError` message is used in pipeline check output, skip stack trace to make it easier to read.

**Error handling improvements:**

* Added explicit handling for `pydantic.ValidationError` in the `main` function of `hooks/pre_run.py`, logging the error and exiting with an error code. [[1]](diffhunk://#diff-cf709ac2096dbe6c98a19716b4cba5eaa840aa655cb38df6ece115609e822544R7) [[2]](diffhunk://#diff-cf709ac2096dbe6c98a19716b4cba5eaa840aa655cb38df6ece115609e822544R31-R33)

**Unit test enhancements:**

* Added a test case to `tests/test_pre_run.py` that simulates a `ValidationError` during deployment management, verifying correct logging and exit code.
* Updated existing tests in `tests/test_pre_run.py` and `tests/test_post_run.py` to patch logging and assert that appropriate log messages are emitted for various scenarios, including successful runs, pending prepares, and rerun markers. [[1]](diffhunk://#diff-247d5e2ddde7ddebf3ea1b2f00c8d3be23735dea3d57a6d18bfc4c9df13585c2R40-R46) [[2]](diffhunk://#diff-247d5e2ddde7ddebf3ea1b2f00c8d3be23735dea3d57a6d18bfc4c9df13585c2R87) [[3]](diffhunk://#diff-247d5e2ddde7ddebf3ea1b2f00c8d3be23735dea3d57a6d18bfc4c9df13585c2R110-R119) [[4]](diffhunk://#diff-247d5e2ddde7ddebf3ea1b2f00c8d3be23735dea3d57a6d18bfc4c9df13585c2R141-R152) [[5]](diffhunk://#diff-200bac98367daafb5df9452704bd661b9958de83dc7cb9072aa2c7f53f03dcacR16-R36) [[6]](diffhunk://#diff-200bac98367daafb5df9452704bd661b9958de83dc7cb9072aa2c7f53f03dcacR46)

**Test parameterization and coverage:**

* Improved test parameterization in both `pre_run` and `post_run` tests to cover different exit codes and log messages for dry runs and rerun marker cases. [[1]](diffhunk://#diff-200bac98367daafb5df9452704bd661b9958de83dc7cb9072aa2c7f53f03dcacR16-R36) [[2]](diffhunk://#diff-200bac98367daafb5df9452704bd661b9958de83dc7cb9072aa2c7f53f03dcacR46) [[3]](diffhunk://#diff-247d5e2ddde7ddebf3ea1b2f00c8d3be23735dea3d57a6d18bfc4c9df13585c2R141-R152) [[4]](diffhunk://#diff-247d5e2ddde7ddebf3ea1b2f00c8d3be23735dea3d57a6d18bfc4c9df13585c2R169-R195)

**Dependency updates:**

* Imported `ValidationError` from `pydantic` in both `hooks/pre_run.py` and `tests/test_pre_run.py` to support new error handling and test cases. [[1]](diffhunk://#diff-cf709ac2096dbe6c98a19716b4cba5eaa840aa655cb38df6ece115609e822544R7) [[2]](diffhunk://#diff-247d5e2ddde7ddebf3ea1b2f00c8d3be23735dea3d57a6d18bfc4c9df13585c2R5)