### PR TITLE
fix: do not set backup_retention_period=0 on read replicas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/redhat-services-prod/app-sre-tenant/er-base-terraform-main/er-base-terraform-main:0.5.0-6@sha256:d461e7418d12682e7da155c7760cf85b82c5d671e01d10fcb3ac3a1316d78af1 AS base
 # keep in sync with pyproject.toml
-LABEL konflux.additional-tags="0.12.1"
+LABEL konflux.additional-tags="0.12.2"
 
 FROM base AS builder
 COPY --from=ghcr.io/astral-sh/uv:0.11.8@sha256:3b7b60a81d3c57ef471703e5c83fd4aaa33abcd403596fb22ab07db85ae91347 /uv /bin/uv

--- a/er_aws_rds/input.py
+++ b/er_aws_rds/input.py
@@ -253,7 +253,8 @@ class Rds(RdsAppInterface):
         When working with read replicas created in the same region, defaults to the Subnet Group Name of the source DB.
         When working with read replicas created in a different region, defaults to the default Subnet Group.
 
-        backup_retention_period must be 0 for replicas.
+        backup_retention_period is left unmanaged (None) for replicas to avoid
+        conflicting with AWS Backup when it controls the retention period.
         """
         if not self.replica_source:
             return self
@@ -275,7 +276,7 @@ class Rds(RdsAppInterface):
         elif not self.db_subnet_group_name:
             self.replicate_source_db = self.replica_source.identifier
 
-        self.backup_retention_period = 0
+        self.backup_retention_period = None
         return self
 
     @model_validator(mode="after")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-aws-rds"
-version = "0.12.1"
+version = "0.12.2"
 description = "ERv2 module for managing AWS rds instances"
 authors = [{ name = "AppSRE", email = "sd-app-sre@redhat.com" }]
 license = { text = "Apache 2.0" }

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -395,7 +395,7 @@ def test_same_region_replica_without_db_subnet_group_name() -> None:
     model = AppInterfaceInput.model_validate(mod_input)
     assert model.data.replicate_source_db == "test-rds-source"
     assert model.data.db_subnet_group_name is None
-    assert model.data.backup_retention_period == 0
+    assert model.data.backup_retention_period is None
 
 
 def test_same_region_replica_with_db_subnet_group_name() -> None:
@@ -412,7 +412,7 @@ def test_same_region_replica_with_db_subnet_group_name() -> None:
     model = AppInterfaceInput.model_validate(mod_input)
     assert model.data.replicate_source_db is None
     assert model.data.db_subnet_group_name == "custom-subnet-group"
-    assert model.data.backup_retention_period == 0
+    assert model.data.backup_retention_period is None
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "er-aws-rds"
-version = "0.12.1"
+version = "0.12.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

- Read replicas managed by AWS Backup reject `BackupRetentionPeriod=0` — AWS requires the value to match the current retention or be left unset
- Changed `backup_retention_period` from `0` to `None` for replicas so Terraform leaves the attribute unmanaged, avoiding the `InvalidParameterValue` error
- Bumped version to `0.12.2`

## Test plan

- [ ] Existing test suite passes (`pytest tests/`)
- [ ] Deploy against `rbac-prod-readonly` or similar AWS Backup-managed replica and confirm no `InvalidParameterValue` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)