### PR TITLE
feat: support old_parameter_group to prevent deletion during engine upgrades

### DIFF
--- a/er_aws_rds/input.py
+++ b/er_aws_rds/input.py
@@ -121,6 +121,7 @@ class RdsAppInterface(BaseModel):
     aws_partition: str | None = Field(default="aws", exclude=True)
     region: str = Field(exclude=True)
     parameter_group: ParameterGroup | None = Field(default=None, exclude=True)
+    old_parameter_group: ParameterGroup | None = Field(default=None, exclude=True)
     blue_green_deployment: BlueGreenDeployment | None = Field(
         default=None, exclude=True
     )
@@ -308,6 +309,11 @@ class Rds(RdsAppInterface):
             self.parameter_group.name = name
             self.parameter_group_name = name
 
+        if self.old_parameter_group:
+            self.old_parameter_group.name = (
+                f"{self.identifier}-{self.old_parameter_group.name or 'pg'}"
+            )
+
         if (
             self.blue_green_deployment
             and self.blue_green_deployment.target
@@ -480,6 +486,8 @@ class TerraformModuleData(BaseModel):
             and (pg != parameter_group)
         ):
             parameter_groups.append(pg)
+        if self.ai_input.data.old_parameter_group:
+            parameter_groups.append(self.ai_input.data.old_parameter_group)
         return parameter_groups
 
     @computed_field

--- a/tests/test_input_terraform.py
+++ b/tests/test_input_terraform.py
@@ -70,3 +70,29 @@ def test_parameter_groups_when_blue_green_deployment_has_duplicate() -> None:
     tf_model = TerraformModuleData(ai_input=model).model_dump()
 
     assert tf_model["parameter_groups"] == [EXPECTED_DEFAULT_PARAMETER_GROUP]
+
+
+OLD_PARAMETER_GROUP = {
+    "name": "old-pg",
+    "family": "postgres13",
+    "description": "Parameter Group for PostgreSQL 13",
+    "parameters": [],
+}
+EXPECTED_OLD_PARAMETER_GROUP = OLD_PARAMETER_GROUP | {
+    "name": "test-rds-old-pg",
+}
+
+
+def test_parameter_groups_with_old_parameter_group() -> None:
+    """Test old_parameter_group is included in parameter_groups"""
+    model = input_object({
+        "data": {
+            "old_parameter_group": OLD_PARAMETER_GROUP,
+        }
+    })
+    tf_model = TerraformModuleData(ai_input=model).model_dump()
+
+    assert tf_model["parameter_groups"] == [
+        EXPECTED_DEFAULT_PARAMETER_GROUP,
+        EXPECTED_OLD_PARAMETER_GROUP,
+    ]

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -37,6 +37,38 @@ def test_parameter_group_name_without_pg_name() -> None:
     assert model.data.parameter_group.name == f"{model.data.identifier}-pg"
 
 
+def test_old_parameter_group_name() -> None:
+    """Test correct old parameter group name is set"""
+    mod_input = input_data({
+        "data": {
+            "old_parameter_group": {
+                "name": "old-pg",
+                "family": "postgres13",
+                "description": "Parameter Group for PostgreSQL 13",
+                "parameters": [],
+            }
+        }
+    })
+    model = AppInterfaceInput.model_validate(mod_input)
+    assert model.data.old_parameter_group is not None
+    assert model.data.old_parameter_group.name == f"{model.data.identifier}-old-pg"
+
+
+def test_old_parameter_group_name_without_pg_name() -> None:
+    """Test old parameter group name defaults to identifier-pg"""
+    mod_input = input_data({
+        "data": {
+            "old_parameter_group": {
+                "name": None,
+                "family": "postgres13",
+            }
+        }
+    })
+    model = AppInterfaceInput.model_validate(mod_input)
+    assert model.data.old_parameter_group is not None
+    assert model.data.old_parameter_group.name == f"{model.data.identifier}-pg"
+
+
 def test_blue_green_deployment_parameter_group_default_name() -> None:
     """Test Blue/Green Deployment parameter group default name"""
     mod_input = input_data({


### PR DESCRIPTION
## Summary
- Add `old_parameter_group` field to `RdsAppInterface` so the old parameter group is kept in the Terraform `for_each` map during major version upgrades
- Apply identifier prefix to `old_parameter_group.name` (same as `parameter_group`)
- Include `old_parameter_group` in `TerraformModuleData.parameter_groups` output

## Problem
During an RDS major version upgrade (e.g. PostgreSQL 14 → 16), Terraform updates the DB instance to reference the new parameter group, then immediately tries to destroy the old one. This fails with `InvalidDBParameterGroupState` because RDS still considers the instance a member of the old parameter group.

## Solution
Accept an `old_parameter_group` in the input so both the old and new parameter groups remain in the Terraform state. The old group can be removed from the input in a follow-up MR once the upgrade is fully settled.

## Depends on
- https://github.com/app-sre/qontract-reconcile/pull/5600

## Test plan
- [x] `test_old_parameter_group_name` — identifier prefix applied
- [x] `test_old_parameter_group_name_without_pg_name` — fallback name when name is None
- [x] `test_parameter_groups_with_old_parameter_group` — included in terraform output
- [x] All 206 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)